### PR TITLE
Add release tooling and enhanced install scripts with version locking

### DIFF
--- a/Dockerfile.darcs-test
+++ b/Dockerfile.darcs-test
@@ -10,9 +10,17 @@ FROM debian:bookworm
 # Prevent interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Darcs from Debian repos
+# Install Darcs and build tooling (used for local install tests)
 RUN apt-get update \
-    && apt-get install -y darcs ca-certificates \
+    && apt-get install -y \
+        darcs \
+        ca-certificates \
+        build-essential \
+        patch \
+        gawk \
+        curl \
+        tar \
+        wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Verify installation

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Basilisk C is a powerful open-source computational fluid dynamics (CFD) framewor
 - **Interactive Visualization**: Real-time 3D visualization using WebGL
 - **Memory Management**: Built-in memory tracing and profiling tools
 - **Extensible Architecture**: Modular design allowing easy addition of new physical models
-- **Local Visualization Server**: Support for offline 3D visualization using a [local bview client](https://github.com/comphy-lab/bview-local-client)
+- **Local Visualization Server**: Offline 3D visualization using a [local bview client](https://github.com/comphy-lab/bview-local-client) (manual URL works without patches; optional `--local-bview` installer flag enables `bview --local` convenience output — see `Tips.md`)
 
 ### Getting Started
 

--- a/Tips.md
+++ b/Tips.md
@@ -83,7 +83,7 @@ The workflow file is located at `.github/workflows/sync-darcs-repositories.yml`.
 
 ## Installing Basilisk
 
-We provide three installation scripts depending on your system and available tools:
+We provide four installation scripts depending on your system and available tools:
 
 ### Option 1: Using Darcs (macOS with Homebrew)
 
@@ -125,6 +125,45 @@ This script:
 
 **Requirements**: `wget`, `tar`, `make`, `gcc`, `gawk`
 
+### Option 4: Ref-Locked Install (Reproducible, HPC-friendly)
+
+Use this when you want to lock Basilisk + patches to a GitHub **Release tag** in `comphy-lab/basilisk-C`.
+
+```shell
+./reset_install_basilisk-ref-locked.sh --ref=v2026-01-13 --hard
+```
+
+Equivalent (using the unified installer):
+
+```shell
+./reset_install_basilisk.sh --mode=4 --ref=v2026-01-13 --hard
+```
+
+This script:
+1. Downloads the OS-specific tarball attached to the Release tag (`basilisk-mac.tar.gz` or `basilisk-linux.tar.gz`)
+2. Builds Basilisk and writes a lock stamp to `basilisk/.comphy-lock`
+
+**Requirements**: `curl`, `tar`, `make`, `gcc`, `gawk` (plus `patch` only if using `--local-bview`)
+
+### Creating a Ref-Locked Release (Maintainers)
+
+This repo includes `release-comphy-tag.sh` to create a reproducible, ref-locked Release tag and publish OS-specific, pre-patched Basilisk source tarballs.
+
+```shell
+./release-comphy-tag.sh
+# or
+./release-comphy-tag.sh --tag=v2026-01-13
+```
+
+This script:
+1. Pulls the latest upstream Basilisk snapshot into `basilisk-source/` using `darcs`
+2. Runs install tests (`reset_install_basilisk.sh --mode=1 --hard`):
+   - macOS: tests macOS natively + Linux in Docker (`darcs-test` image)
+   - Linux: tests Linux natively
+3. Builds and uploads GitHub Release assets:
+   - `basilisk-mac.tar.gz` (+ `.sha256`): upstream snapshot + macOS + common patches (**local-bview not applied**)
+   - `basilisk-linux.tar.gz` (+ `.sha256`): upstream snapshot + common patches (**local-bview not applied**, macOS patches excluded)
+
 ### Clean Reinstall
 
 For any script, use the `--hard` flag to remove existing installation and start fresh:
@@ -135,6 +174,8 @@ For any script, use the `--hard` flag to remove existing installation and start 
 ./reset_install_basilisk-no-darcs.sh --hard
 # or
 ./reset_install_basilisk-no-darcs-no-git.sh --hard
+# or (ref-locked)
+./reset_install_basilisk-ref-locked.sh --ref=v2026-01-13 --hard
 ```
 
 ### Manual Installation

--- a/Tips.md
+++ b/Tips.md
@@ -245,7 +245,7 @@ These templates help us gather all the necessary information to diagnose and fix
 
 ## Using bview with a Local Client
 
-By default, `bview` uses the remote JavaScript client hosted at basilisk.fr for 3D visualization. For offline development or faster loading, you can use a local client instead.
+By default, `bview2D`/`bview3D` prints a URL which uses the remote JavaScript client (served from `basilisk.ida.upmc.fr`). For offline use or faster loading, you can serve the client locally using [bview-local-client](https://github.com/comphy-lab/bview-local-client).
 
 ### Setup
 
@@ -253,15 +253,37 @@ By default, `bview` uses the remote JavaScript client hosted at basilisk.fr for 
    ```shell
    git clone https://github.com/comphy-lab/bview-local-client.git
    cd bview-local-client
-   # Start a local HTTP server (e.g., using Python)
-   python3 -m http.server 8000
+   ./deploy.sh  # serves http://localhost:8000/three.js/editor/index.html
    ```
 
-2. Run bview with the `--local` flag:
+### Option A: No Basilisk patch (manual URL)
+
+This works with upstream Basilisk as-is: run `bview` normally, then use the local client URL and keep the `?ws://...` part from the printed output.
+
+```shell
+bview2D dump
+# Example output:
+#   http://basilisk.ida.upmc.fr/three.js/editor/index.html?ws://your-hostname:7101
+
+# Open the local client and append the websocket query:
+#   http://localhost:8000/three.js/editor/index.html?ws://your-hostname:7101
+```
+
+### Option B: Optional convenience patch (prints localhost URL)
+
+`patches/2026-01-06-local-bview.patch` is an optional, aesthetic/convenience patch: it only changes the JavaScript client base URL that `bview` prints (and what `display.html` redirects to). It does **not** change the websocket connection (which always connects back to your local `bview` process).
+
+To enable it, install Basilisk with `--local-bview` (not applied by default), then run `bview` with the `--local` flag:
    ```shell
+   # installer examples
+   ./reset_install_basilisk.sh --mode=1 --local-bview --hard
+   ./reset_install_basilisk.sh --mode=4 --ref=v2026-01-13 --local-bview --hard
+
+   # usage
    bview2D --local dump      # Uses localhost:8000
    bview3D --local=3000 dump # Uses localhost:3000
    ```
+   **Note:** `--local` hardcodes `localhost`. If you want to open the visualization from another machine, use Option A and replace the base URL with the correct IP/hostname.
 
 ### How It Works
 
@@ -269,6 +291,8 @@ The visualization URL has two parts:
 - **HTTP server**: Serves the JavaScript 3D client (static files)
 - **WebSocket**: Connects back to your local bview process
 
-The `--local` flag only changes where the JS client is served from—the WebSocket always connects to your local bview process regardless.
+The local-bview patch only changes where the JS client is served from—the websocket always connects to your local bview process regardless.
+
+**Note:** Our GitHub Release tarballs (`basilisk-mac.tar.gz` / `basilisk-linux.tar.gz`) intentionally exclude `2026-01-06-local-bview.patch`. If you want `bview --local` with a ref-locked install, pass `--local-bview` so the installer downloads and applies the patch for that same `--ref`.
 
 For more details, see the [bview-local-client repository](https://github.com/comphy-lab/bview-local-client).

--- a/patches/2026-01-06-local-bview.patch
+++ b/patches/2026-01-06-local-bview.patch
@@ -1,11 +1,15 @@
 # Patch: local-bview
 # Author: Vatsal Sanjay <vatsal.sanjay@comphy-lab.org>
 # Date: 2026-01-06
-# Description: Add --local flag to bview for offline visualization
+# Description: Optional convenience: bview --local prints localhost client URL
 #
-# By default, bview uses the remote JavaScript client hosted at basilisk.fr.
-# This patch adds support for using a locally-hosted client instead, enabling
-# offline visualization and faster loading during development.
+# By default, bview prints a URL which uses the remote JavaScript client
+# (served from basilisk.ida.upmc.fr). You can still use a local client without
+# this patch by replacing the base URL and keeping the '?ws://...' query.
+#
+# This patch adds an optional runtime override (display_set_js_base) and a
+# --local/--local=PORT flag so the printed URL (and display.html redirect)
+# points at http://localhost:PORT/three.js/editor/index.html.
 #
 # New options:
 #   --local        Use localhost:8000 for the JavaScript client
@@ -13,6 +17,9 @@
 #
 # The WebSocket connection always connects back to the local bview process
 # regardless of where the JS client is served from.
+#
+# Note: comphy-lab GitHub Release tarballs intentionally exclude this patch.
+#       Enable via installer flag: --local-bview
 #
 # Related: https://github.com/comphy-lab/bview-local-client
 # Platform: All

--- a/patches/README.md
+++ b/patches/README.md
@@ -61,18 +61,20 @@ error: implicit declaration of function 'madvise'
 **Files modified:** `src/bview.c`, `src/display.h`
 **Related:** [bview-local-client](https://github.com/comphy-lab/bview-local-client)
 
-Adds support for using a locally-hosted JavaScript client with bview instead of the remote client at basilisk.fr. This enables offline visualization and faster loading times during development.
+Optional, aesthetic/convenience patch: adds `bview --local` / `bview --local=PORT` so the URL printed by `bview` (and the `display.html` redirect) points at a locally-served JavaScript client (e.g., `bview-local-client`).
+
+You can use `bview-local-client` **without** this patch by manually swapping the base URL host and keeping the `?ws://...` query string printed by `bview`.
 
 **What it adds:**
 - `--local` flag: Uses `localhost:8000` for the JavaScript client
 - `--local=PORT` flag: Uses `localhost:PORT` for custom port configurations
 - `display_set_js_base()` function for runtime URL override
-- Proper usage help with `-h` flag
+- Port validation + a usage message on invalid `--local` arguments
 
 **Usage:**
 ```shell
 # Start local client server first
-cd bview-local-client && python3 -m http.server 8000
+cd bview-local-client && ./deploy.sh
 
 # Then run bview with --local
 bview2D --local dump
@@ -80,6 +82,9 @@ bview3D --local=3000 dump
 ```
 
 **Note:** The `--local` flag only changes where the JavaScript client is served from. The WebSocket connection always connects back to your local bview process.
+`--local` hardcodes `localhost`; for viewing from another machine, use the manual URL approach and replace the base URL host with the correct IP/hostname.
+
+**Packaging note:** Our GitHub Release tarballs intentionally exclude this patch. To enable it during installation, pass `--local-bview` to the installer (including ref-locked installs with `--ref=...`).
 
 ---
 

--- a/release-comphy-tag.sh
+++ b/release-comphy-tag.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# Create a comphy-lab Basilisk release tag and publish OS-specific, pre-patched
+# Basilisk source tarballs as GitHub Release assets.
+#
+# - Source snapshot comes from upstream (darcs) pulled into basilisk-source/
+# - Patches come from patches/ and are applied before packaging
+# - Produces two tarballs:
+#     basilisk-mac.tar.gz   (includes macOS patches + all non-macOS patches)
+#     basilisk-linux.tar.gz (includes all non-macOS patches)
+#   The local-bview patch is NOT applied to either tarball.
+#
+# This script also runs install tests:
+# - On macOS: tests macOS install natively and Linux install in Docker
+# - On Linux: tests Linux install natively
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+
+TAG=""
+DRY_RUN=false
+SKIP_TESTS=false
+FORCE=false
+
+usage() {
+  cat <<'EOF'
+Usage: ./release-comphy-tag.sh [OPTIONS]
+
+Options:
+  --tag=TAG        Release tag name (default: vYYYY-MM-DD in UTC)
+  --skip-tests     Skip install tests
+  --dry-run        Print actions without pushing/tagging/releasing
+  --force          Delete/recreate local tag if it exists (still fails if remote tag exists)
+  --help, -h       Show this help message
+
+Notes:
+  - Requires gh auth and push access to the repo.
+  - Produces and uploads these GitHub Release assets:
+      basilisk-mac.tar.gz (+ .sha256)
+      basilisk-linux.tar.gz (+ .sha256)
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --tag=*)
+      TAG="${arg#*=}"
+      ;;
+    --skip-tests)
+      SKIP_TESTS=true
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    --force)
+      FORCE=true
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown argument: $arg" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  TAG="v$(date -u +%Y-%m-%d)"
+fi
+
+print_cyan() { printf "\033[0;36m%s\033[0m\n" "$1"; }
+print_green() { printf "\033[0;32m%s\033[0m\n" "$1"; }
+print_red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
+
+require_tool() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    print_red "Error: Missing required tool: $tool"
+    exit 1
+  fi
+}
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file"
+  else
+    shasum -a 256 "$file"
+  fi
+}
+
+copy_basilisk_source_to_stage() {
+  local stage_basilisk_dir="$1"
+  mkdir -p "$stage_basilisk_dir"
+  tar -C "$REPO_ROOT/basilisk-source" -cf - --exclude "_darcs" . | tar -C "$stage_basilisk_dir" -xf -
+}
+
+copy_selected_patches() {
+  local platform="$1" # mac | linux
+  local dest_patches_dir="$2"
+  mkdir -p "$dest_patches_dir"
+
+  local patch_file
+  for patch_file in "$REPO_ROOT"/patches/*.patch; do
+    local patch_name
+    patch_name="$(basename "$patch_file")"
+
+    if [[ "$patch_name" == *"-local-bview.patch" ]]; then
+      continue
+    fi
+    if [[ "$platform" == "linux" ]] && [[ "$patch_name" == *"-macos-"* ]]; then
+      continue
+    fi
+
+    cp "$patch_file" "$dest_patches_dir/"
+  done
+}
+
+apply_patches_in_dir() {
+  local target_dir="$1"
+  local patches_dir="$2"
+
+  local patch_files=()
+  patch_files=($(ls "$patches_dir"/*.patch 2>/dev/null | sort))
+  if [[ ${#patch_files[@]} -eq 0 ]]; then
+    print_red "Error: No patches found in $patches_dir"
+    exit 1
+  fi
+
+  local patch_path
+  for patch_path in "${patch_files[@]}"; do
+    local patch_name
+    patch_name="$(basename "$patch_path")"
+    print_cyan "  Applying $patch_name"
+    if ! (cd "$target_dir" && patch -p1 < "$patch_path"); then
+      print_red "Error: Failed to apply $patch_name"
+      exit 1
+    fi
+  done
+}
+
+build_tarball() {
+  local platform="$1" # mac | linux
+  local out_path="$2"
+
+  local stage_dir
+  stage_dir="$(mktemp -d 2>/dev/null || mktemp -d -t basilisk-release)"
+
+  mkdir -p "$stage_dir/basilisk"
+  mkdir -p "$stage_dir/patches"
+
+  print_cyan "Preparing $platform tarball staging dir: $stage_dir"
+  copy_basilisk_source_to_stage "$stage_dir/basilisk"
+  copy_selected_patches "$platform" "$stage_dir/patches"
+
+  print_cyan "Applying patches for $platform..."
+  apply_patches_in_dir "$stage_dir/basilisk" "$stage_dir/patches"
+
+  tar -C "$stage_dir" -czf "$out_path" basilisk patches
+  print_green "Created: $out_path"
+
+  rm -rf "$stage_dir"
+}
+
+run_host_install_test() {
+  local test_dir
+  test_dir="$(mktemp -d 2>/dev/null || mktemp -d -t basilisk-test)"
+
+  print_cyan "Running host install test in: $test_dir"
+  cp "$REPO_ROOT/reset_install_basilisk.sh" "$test_dir/"
+  cp -R "$REPO_ROOT/patches" "$test_dir/patches"
+  chmod +x "$test_dir/reset_install_basilisk.sh"
+
+  (cd "$test_dir" && ./reset_install_basilisk.sh --mode=1 --hard)
+  rm -rf "$test_dir"
+}
+
+run_linux_install_test_in_docker() {
+  local image_name="darcs-test"
+
+  if ! docker info >/dev/null 2>&1; then
+    print_red "Error: Docker is not running"
+    exit 1
+  fi
+
+  if ! docker image inspect "$image_name" >/dev/null 2>&1; then
+    print_cyan "Docker image '$image_name' not found. Building..."
+    docker build -f "$REPO_ROOT/Dockerfile.darcs-test" -t "$image_name" "$REPO_ROOT"
+  fi
+
+  print_cyan "Running Linux install test in Docker..."
+  docker run --rm -v "$REPO_ROOT":/repo:ro "$image_name" bash -lc "\
+    set -euo pipefail && \
+    mkdir -p /work && cd /work && \
+    cp /repo/reset_install_basilisk.sh . && \
+    cp -R /repo/patches ./patches && \
+    chmod +x reset_install_basilisk.sh && \
+    ./reset_install_basilisk.sh --mode=1 --hard \
+  "
+}
+
+cd "$REPO_ROOT"
+
+require_tool git
+require_tool darcs
+require_tool tar
+require_tool patch
+require_tool gh
+
+if [[ "$SKIP_TESTS" == false ]]; then
+  require_tool make
+  require_tool gcc
+  require_tool gawk
+  require_tool curl
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    require_tool docker
+  fi
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  print_red "Error: gh is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  print_red "Error: Working tree not clean. Commit/stash changes before releasing."
+  git status --porcelain
+  exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$branch" != "main" ]]; then
+  print_red "Error: Must be on 'main' branch to release (current: $branch)"
+  exit 1
+fi
+
+if ! git remote get-url origin >/dev/null 2>&1; then
+  print_red "Error: Missing 'origin' git remote"
+  exit 1
+fi
+
+print_cyan "Fetching origin..."
+git fetch origin --tags
+git pull --ff-only origin main
+
+if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+  print_red "Error: Tag already exists on origin: $TAG"
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  if [[ "$FORCE" == true ]]; then
+    print_cyan "Deleting existing local tag: $TAG"
+    git tag -d "$TAG"
+  else
+    print_red "Error: Tag already exists locally: $TAG"
+    exit 1
+  fi
+fi
+
+print_cyan "Syncing basilisk-source from upstream darcs..."
+if [[ ! -d "$REPO_ROOT/basilisk-source/_darcs" ]]; then
+  print_red "Error: Missing darcs repo at basilisk-source/_darcs"
+  exit 1
+fi
+(cd "$REPO_ROOT/basilisk-source" && darcs pull --all)
+
+if [[ -n "$(git status --porcelain basilisk-source)" ]]; then
+  print_cyan "Committing basilisk-source changes..."
+  git add basilisk-source
+  git commit -m "Update basilisk-source from Darcs ($TAG)"
+fi
+
+if [[ "$SKIP_TESTS" == false ]]; then
+  print_cyan "Running install tests..."
+  run_host_install_test
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    run_linux_install_test_in_docker
+  fi
+fi
+
+artifacts_dir="$(mktemp -d 2>/dev/null || mktemp -d -t basilisk-artifacts)"
+print_cyan "Artifacts directory: $artifacts_dir"
+
+mac_tar="$artifacts_dir/basilisk-mac.tar.gz"
+linux_tar="$artifacts_dir/basilisk-linux.tar.gz"
+
+build_tarball "mac" "$mac_tar"
+build_tarball "linux" "$linux_tar"
+
+sha256_file "$mac_tar" > "$mac_tar.sha256"
+sha256_file "$linux_tar" > "$linux_tar.sha256"
+
+print_green "Checksums:"
+cat "$mac_tar.sha256"
+cat "$linux_tar.sha256"
+
+release_notes="$artifacts_dir/release-notes.md"
+cat > "$release_notes" <<EOF
+Ref-locked Basilisk release \`$TAG\`.
+
+Assets:
+- \`basilisk-mac.tar.gz\`: Basilisk source (darcs snapshot) + comphy-lab patches for macOS (local-bview not applied)
+- \`basilisk-linux.tar.gz\`: Basilisk source (darcs snapshot) + comphy-lab patches for Linux (local-bview not applied)
+
+Install (ref-locked):
+- \`./reset_install_basilisk.sh --mode=4 --ref=$TAG --hard\`
+- \`./reset_install_basilisk-ref-locked.sh --ref=$TAG --hard\`
+EOF
+
+if [[ "$DRY_RUN" == true ]]; then
+  print_cyan "Dry run: would create tag, push, and publish GitHub release:"
+  echo "  tag: $TAG"
+  echo "  assets: $mac_tar $linux_tar $mac_tar.sha256 $linux_tar.sha256"
+  exit 0
+fi
+
+print_cyan "Creating annotated tag: $TAG"
+git tag -a "$TAG" -m "comphy-lab Basilisk release $TAG"
+
+print_cyan "Pushing main and tag..."
+git push origin main
+git push origin "$TAG"
+
+print_cyan "Creating GitHub Release and uploading assets..."
+gh release create "$TAG" \
+  "$mac_tar" "$linux_tar" "$mac_tar.sha256" "$linux_tar.sha256" \
+  --title "$TAG" \
+  --notes-file "$release_notes"
+
+print_green "✅ Release published: $TAG"
+print_green "Artifacts kept at: $artifacts_dir"

--- a/reset_install_basilisk-darcs.sh
+++ b/reset_install_basilisk-darcs.sh
@@ -277,14 +277,47 @@ if [[ ! -d "$BASILISK_SRC_DIR" ]]; then
     echo "\033[0;31mError: Expected $BASILISK_SRC_DIR to exist before writing .project_config\033[0m"
     exit 1
 fi
-printf "export BASILISK=%s\n" "$BASILISK_SRC_DIR" > "$PROJECT_CONFIG"
-# Prepend BASILISK to PATH so Basilisk tools (qcc, etc.) take precedence
-printf "export PATH=\$BASILISK:\$PATH\n" >> "$PROJECT_CONFIG"
+{
+    printf 'export BASILISK="%s"\n' "$BASILISK_SRC_DIR"
+    cat <<'EOF'
+
+if [ ! -d "$BASILISK" ]; then
+  echo "Error: BASILISK directory not found: $BASILISK" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Ensure the repo-installed Basilisk takes precedence, without duplicating PATH
+_PATH=":$PATH:"
+_PATH="${_PATH//:$BASILISK:/:}"
+_PATH="${_PATH#:}"
+_PATH="${_PATH%:}"
+export PATH="$BASILISK${_PATH:+:$_PATH}"
+unset _PATH
+
+# Refresh command lookup cache (best-effort)
+hash -r 2>/dev/null || true
+rehash 2>/dev/null || true
+EOF
+} > "$PROJECT_CONFIG"
 
 source "$PROJECT_CONFIG"
 
 # Check if qcc is working properly
 printf '\nChecking qcc installation...\n'
+qcc_path="$(command -v qcc 2>/dev/null || true)"
+if [[ -z "$qcc_path" ]]; then
+    echo "\033[0;31mError: qcc not found on PATH after sourcing .project_config\033[0m"
+    exit 1
+fi
+if [[ "$qcc_path" != /* ]]; then
+    echo "\033[0;31mError: qcc resolves to a non-path ('$qcc_path'). This is likely an alias/function.\033[0m"
+    exit 1
+fi
+if [[ "$qcc_path" != "$BASILISK/"* ]]; then
+    echo "\033[0;31mError: qcc resolves to '$qcc_path' but expected it under '$BASILISK/'.\033[0m"
+    echo "\033[0;31mThis usually means a global Basilisk install is taking precedence.\033[0m"
+    exit 1
+fi
 if ! qcc --version > /dev/null 2>&1; then
     echo "\033[0;31mError: qcc is not working properly.\033[0m"
     echo "Please ensure you have Xcode Command Line Tools installed."

--- a/reset_install_basilisk-no-darcs-no-git.sh
+++ b/reset_install_basilisk-no-darcs-no-git.sh
@@ -299,15 +299,48 @@ if [[ ! -d "$BASILISK_SRC_DIR" ]]; then
     printf "\033[0;31mError: Expected $BASILISK_SRC_DIR to exist before writing .project_config\033[0m\n" >&2
     exit 1
 fi
-printf "export BASILISK=%s\n" "$BASILISK_SRC_DIR" > "$PROJECT_CONFIG"
-# Prepend BASILISK to PATH so Basilisk tools (qcc, etc.) take precedence
-printf "export PATH=\$BASILISK:\$PATH\n" >> "$PROJECT_CONFIG"
+{
+    printf 'export BASILISK="%s"\n' "$BASILISK_SRC_DIR"
+    cat <<'EOF'
+
+if [ ! -d "$BASILISK" ]; then
+  echo "Error: BASILISK directory not found: $BASILISK" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Ensure the repo-installed Basilisk takes precedence, without duplicating PATH
+_PATH=":$PATH:"
+_PATH="${_PATH//:$BASILISK:/:}"
+_PATH="${_PATH#:}"
+_PATH="${_PATH%:}"
+export PATH="$BASILISK${_PATH:+:$_PATH}"
+unset _PATH
+
+# Refresh command lookup cache (best-effort)
+hash -r 2>/dev/null || true
+rehash 2>/dev/null || true
+EOF
+} > "$PROJECT_CONFIG"
 
 source "$PROJECT_CONFIG"
 
 # Check if qcc is working properly
 echo ""
 printf "\033[0;36mChecking qcc installation...\033[0m\n"
+qcc_path="$(command -v qcc 2>/dev/null || true)"
+if [[ -z "$qcc_path" ]]; then
+    printf "\033[0;31mError: qcc not found on PATH after sourcing .project_config\033[0m\n" >&2
+    exit 1
+fi
+if [[ "$qcc_path" != /* ]]; then
+    printf "\033[0;31mError: qcc resolves to a non-path ('$qcc_path'). This is likely an alias/function.\033[0m\n" >&2
+    exit 1
+fi
+if [[ "$qcc_path" != "$BASILISK/"* ]]; then
+    printf "\033[0;31mError: qcc resolves to '$qcc_path' but expected it under '$BASILISK/'.\033[0m\n" >&2
+    printf "\033[0;31mThis usually means a global Basilisk install is taking precedence.\033[0m\n" >&2
+    exit 1
+fi
 if ! qcc --version > /dev/null 2>&1; then
     printf "\033[0;31mError: qcc is not working properly.\033[0m\n"
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/reset_install_basilisk-no-darcs.sh
+++ b/reset_install_basilisk-no-darcs.sh
@@ -295,15 +295,48 @@ if [[ ! -d "$BASILISK_SRC_DIR" ]]; then
     printf "\033[0;31mError: Expected $BASILISK_SRC_DIR to exist before writing .project_config\033[0m\n" >&2
     exit 1
 fi
-printf "export BASILISK=%s\n" "$BASILISK_SRC_DIR" > "$PROJECT_CONFIG"
-# Prepend BASILISK to PATH so Basilisk tools (qcc, etc.) take precedence
-printf "export PATH=\$BASILISK:\$PATH\n" >> "$PROJECT_CONFIG"
+{
+    printf 'export BASILISK="%s"\n' "$BASILISK_SRC_DIR"
+    cat <<'EOF'
+
+if [ ! -d "$BASILISK" ]; then
+  echo "Error: BASILISK directory not found: $BASILISK" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Ensure the repo-installed Basilisk takes precedence, without duplicating PATH
+_PATH=":$PATH:"
+_PATH="${_PATH//:$BASILISK:/:}"
+_PATH="${_PATH#:}"
+_PATH="${_PATH%:}"
+export PATH="$BASILISK${_PATH:+:$_PATH}"
+unset _PATH
+
+# Refresh command lookup cache (best-effort)
+hash -r 2>/dev/null || true
+rehash 2>/dev/null || true
+EOF
+} > "$PROJECT_CONFIG"
 
 source "$PROJECT_CONFIG"
 
 # Check if qcc is working properly
 echo ""
 printf "\033[0;36mChecking qcc installation...\033[0m\n"
+qcc_path="$(command -v qcc 2>/dev/null || true)"
+if [[ -z "$qcc_path" ]]; then
+    printf "\033[0;31mError: qcc not found on PATH after sourcing .project_config\033[0m\n" >&2
+    exit 1
+fi
+if [[ "$qcc_path" != /* ]]; then
+    printf "\033[0;31mError: qcc resolves to a non-path ('$qcc_path'). This is likely an alias/function.\033[0m\n" >&2
+    exit 1
+fi
+if [[ "$qcc_path" != "$BASILISK/"* ]]; then
+    printf "\033[0;31mError: qcc resolves to '$qcc_path' but expected it under '$BASILISK/'.\033[0m\n" >&2
+    printf "\033[0;31mThis usually means a global Basilisk install is taking precedence.\033[0m\n" >&2
+    exit 1
+fi
 if ! qcc --version > /dev/null 2>&1; then
     printf "\033[0;31mError: qcc is not working properly.\033[0m\n"
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/reset_install_basilisk-ref-locked.sh
+++ b/reset_install_basilisk-ref-locked.sh
@@ -1,0 +1,502 @@
+#!/bin/bash
+# Ref-locked Basilisk installation script
+# Installs Basilisk from OS-specific tarballs attached to a GitHub Release tag
+# in comphy-lab/basilisk-C for reproducible installs (no darcs/git required).
+#
+# Supported remote usage:
+#   curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | bash -s -- --ref=<tag>
+#   curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | zsh  -s -- --ref=<tag>
+
+set -euo pipefail
+
+HARD_RESET=false
+LOCAL_BVIEW=false
+SHOW_HELP=false
+REF=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --hard)
+      HARD_RESET=true
+      ;;
+    --local-bview)
+      LOCAL_BVIEW=true
+      ;;
+    --help|-h)
+      SHOW_HELP=true
+      ;;
+    --ref=*)
+      REF="${arg#*=}"
+      ;;
+  esac
+done
+
+print_green() { printf "\033[0;32m%s\033[0m\n" "$1"; }
+print_red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
+print_yellow() { printf "\033[0;33m%s\033[0m\n" "$1"; }
+print_cyan() { printf "\033[0;36m%s\033[0m\n" "$1"; }
+
+PATCHES_API_URL="https://api.github.com/repos/comphy-lab/basilisk-C/contents/patches"
+
+show_help() {
+  cat << 'EOF'
+Ref-locked Basilisk Installation Script
+======================================
+
+Installs Basilisk from OS-specific tarballs attached to a GitHub Release tag in
+comphy-lab/basilisk-C.
+
+Usage:
+  ./reset_install_basilisk-ref-locked.sh [OPTIONS]
+
+Options:
+  --help, -h      Show this help message
+  --hard          Force reinstall (removes existing basilisk directory)
+  --local-bview   Apply the local-bview patch for localhost JavaScript client
+  --ref=REF       Required. GitHub Release tag in comphy-lab/basilisk-C
+
+Examples:
+  ./reset_install_basilisk-ref-locked.sh --ref=v2026-01-13 --hard
+
+Remote:
+  curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | bash -s -- --ref=v2026-01-13 --hard
+  curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | zsh  -s -- --ref=v2026-01-13 --hard
+EOF
+}
+
+check_tool() {
+  local tool="$1"
+  if command -v "$tool" >/dev/null 2>&1; then
+    print_green "✓ $tool is installed"
+    return 0
+  fi
+  return 1
+}
+
+show_install_instructions() {
+  local tool="$1"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    case "$tool" in
+      make|gcc)
+        echo "  xcode-select --install"
+        ;;
+      gawk)
+        echo "  brew install gawk"
+        ;;
+      curl)
+        echo "  brew install curl"
+        ;;
+      tar|patch)
+        echo "  (should be pre-installed on macOS)"
+        ;;
+    esac
+  else
+    case "$tool" in
+      make|gcc)
+        echo "  sudo apt install build-essential"
+        ;;
+      gawk|curl|tar|patch)
+        echo "  sudo apt install $tool"
+        ;;
+    esac
+  fi
+}
+
+check_prerequisites() {
+  local missing_tools=()
+
+  echo "Checking prerequisites..."
+  echo ""
+
+  check_tool "make" || missing_tools+=("make")
+  check_tool "gcc" || missing_tools+=("gcc")
+  check_tool "curl" || missing_tools+=("curl")
+  check_tool "tar" || missing_tools+=("tar")
+  check_tool "gawk" || missing_tools+=("gawk")
+  if [[ "$LOCAL_BVIEW" == "true" ]]; then
+    check_tool "patch" || missing_tools+=("patch")
+  fi
+
+  echo ""
+
+  if [[ ${#missing_tools[@]} -gt 0 ]]; then
+    print_red "Error: Missing required tools: ${missing_tools[*]}"
+    echo ""
+    echo "Installation instructions:"
+    for tool in "${missing_tools[@]}"; do
+      echo "  $tool:"
+      show_install_instructions "$tool"
+    done
+    echo ""
+    echo "Please install the missing tools and try again."
+    exit 1
+  fi
+
+  print_green "✅ All prerequisites are satisfied!"
+  echo ""
+}
+
+read_lock_ref() {
+  local lock_file="$1"
+  local lock_ref=""
+
+  if [[ ! -f "$lock_file" ]]; then
+    echo ""
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    case "$line" in
+      ref=*)
+        lock_ref="${line#ref=}"
+        ;;
+    esac
+  done < "$lock_file"
+
+  echo "$lock_ref"
+}
+
+apply_patches_from_dir() {
+  local target_dir="$1"
+  local patches_dir="$2"
+  local apply_local_bview="${3:-false}"
+  local patch_failed=false
+
+  print_cyan "Applying comphy-lab patches (from pinned ref)..."
+
+  if [[ ! -d "$patches_dir" ]]; then
+    print_red "Error: Missing patches directory: $patches_dir"
+    return 1
+  fi
+
+  local patch_files
+  patch_files=($(ls "$patches_dir"/*.patch 2>/dev/null | sort))
+
+  if [[ ${#patch_files[@]} -eq 0 ]]; then
+    print_yellow "Warning: No patches found in $patches_dir"
+    return 0
+  fi
+
+  for patch_file in "${patch_files[@]}"; do
+    local patch_name
+    patch_name=$(basename "$patch_file")
+
+    if [[ "$patch_name" == *"-local-bview.patch" ]] && [[ "$apply_local_bview" != "true" ]]; then
+      echo "  Skipping $patch_name (use --local-bview to apply)"
+      continue
+    fi
+    if [[ "$patch_name" == *"-macos-"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
+      echo "  Skipping $patch_name (macOS-specific patch)"
+      continue
+    fi
+
+    echo "  Applying $patch_name..."
+    if (cd "$target_dir" && patch -p1 < "$patch_file"); then
+      print_green "  ✓ Successfully applied $patch_name"
+    else
+      print_red "  ✗ Failed to apply $patch_name"
+      patch_failed=true
+    fi
+  done
+
+  echo ""
+
+  if [[ "$patch_failed" == true ]]; then
+    return 1
+  fi
+  return 0
+}
+
+write_lock_stamp() {
+  local lock_file="$1"
+  local ref="$2"
+  local patches_dir="$3"
+  local apply_local_bview="$4"
+
+  local patch_files=()
+  local applied_patches=()
+  local skipped_patches=()
+
+  patch_files=($(ls "$patches_dir"/*.patch 2>/dev/null | sort))
+  for patch_file in "${patch_files[@]}"; do
+    local patch_name
+    patch_name=$(basename "$patch_file")
+
+    if [[ "$patch_name" == *"-local-bview.patch" ]] && [[ "$apply_local_bview" != "true" ]]; then
+      skipped_patches+=("$patch_name")
+      continue
+    fi
+    if [[ "$patch_name" == *"-macos-"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
+      skipped_patches+=("$patch_name")
+      continue
+    fi
+    applied_patches+=("$patch_name")
+  done
+
+  {
+    printf "ref=%s\n" "$ref"
+    printf "created_utc=%s\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date)"
+    printf "local_bview=%s\n" "$apply_local_bview"
+    printf "patches_applied=%s\n" "${applied_patches[*]}"
+    printf "patches_skipped=%s\n" "${skipped_patches[*]}"
+  } > "$lock_file"
+}
+
+build_basilisk() {
+  if ! cd "$BASILISK_SRC_DIR"; then
+    print_red "Error: Failed to change directory to $BASILISK_SRC_DIR"
+    exit 1
+  fi
+
+  if [[ -e config ]]; then
+    rm -f config
+  fi
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    print_cyan "Using macOS configuration..."
+    ln -s config.osx config
+  else
+    print_cyan "Using Linux configuration..."
+    ln -s config.gcc config
+  fi
+
+  print_cyan "Building basilisk (first pass with -k to continue on errors)..."
+  if ! make -k; then
+    print_red "Error: make -k failed in $BASILISK_SRC_DIR"
+    exit 1
+  fi
+
+  print_cyan "Building basilisk (final build)..."
+  if ! make; then
+    print_red "Error: make failed in $BASILISK_SRC_DIR"
+    exit 1
+  fi
+}
+
+write_project_config() {
+  local project_config="$1"
+  local basilisk_src_dir="$2"
+
+  {
+    printf 'export BASILISK="%s"\n' "$basilisk_src_dir"
+    cat <<'EOF'
+
+if [ ! -d "$BASILISK" ]; then
+  echo "Error: BASILISK directory not found: $BASILISK" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Ensure the repo-installed Basilisk takes precedence, without duplicating PATH
+_PATH=":$PATH:"
+_PATH="${_PATH//:$BASILISK:/:}"
+_PATH="${_PATH#:}"
+_PATH="${_PATH%:}"
+export PATH="$BASILISK${_PATH:+:$_PATH}"
+unset _PATH
+
+# Refresh command lookup cache (best-effort)
+hash -r 2>/dev/null || true
+rehash 2>/dev/null || true
+EOF
+  } > "$project_config"
+}
+
+verify_installation() {
+  echo ""
+  print_cyan "Checking qcc installation..."
+
+  local qcc_path
+  qcc_path="$(command -v qcc 2>/dev/null || true)"
+
+  if [[ -z "$qcc_path" ]]; then
+    print_red "Error: qcc not found on PATH after sourcing .project_config"
+    exit 1
+  fi
+
+  if [[ "$qcc_path" != /* ]]; then
+    print_red "Error: qcc resolves to a non-path ('$qcc_path'). This is likely an alias/function."
+    print_red "Remove/disable the alias/function and try again."
+    exit 1
+  fi
+
+  if [[ "$qcc_path" != "$BASILISK/"* ]]; then
+    print_red "Error: qcc resolves to '$qcc_path' but expected it under '$BASILISK/'."
+    print_red "This usually means a global Basilisk install is taking precedence."
+    print_red "Try: 'hash -r' (bash) or 'rehash' (zsh), then re-source .project_config."
+    exit 1
+  fi
+
+  if ! qcc --version >/dev/null 2>&1; then
+    print_red "Error: qcc is not working properly."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      echo "Please ensure you have Xcode Command Line Tools installed."
+      echo "You can install them by running: xcode-select --install"
+    else
+      echo "Please ensure you have build-essential installed."
+      echo "You can install it by running: sudo apt install build-essential"
+    fi
+    exit 1
+  fi
+
+  print_green "✅ qcc is properly installed."
+  qcc --version
+}
+
+if [[ "$SHOW_HELP" == true ]]; then
+  show_help
+  exit 0
+fi
+
+if [[ -z "${REF}" ]]; then
+  print_red "Error: --ref is required"
+  echo ""
+  show_help
+  exit 1
+fi
+
+REPO_ROOT="$PWD"
+if [[ -n "${0:-}" ]] && [[ -f "${0:-}" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  REPO_ROOT="$SCRIPT_DIR"
+fi
+
+PROJECT_CONFIG="$REPO_ROOT/.project_config"
+BASILISK_DIR="$REPO_ROOT/basilisk"
+BASILISK_SRC_DIR="$BASILISK_DIR/src"
+PATCHES_DIR="$REPO_ROOT/patches"
+LOCK_FILE="$BASILISK_DIR/.comphy-lock"
+
+check_prerequisites
+
+rm -rf "$PROJECT_CONFIG"
+
+if [[ "$HARD_RESET" == true ]] || [[ ! -d "$BASILISK_DIR" ]]; then
+  print_cyan "Installing basilisk (ref-locked)..."
+  rm -rf "$BASILISK_DIR"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    asset_name="basilisk-mac.tar.gz"
+  else
+    asset_name="basilisk-linux.tar.gz"
+  fi
+  download_url="https://github.com/comphy-lab/basilisk-C/releases/download/${REF}/${asset_name}"
+
+  temp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t basilisk-C)"
+  if [[ -z "$temp_dir" ]] || [[ ! -d "$temp_dir" ]]; then
+    print_red "Error: Failed to create temp directory"
+    exit 1
+  fi
+
+  print_cyan "Downloading: $download_url"
+  if ! curl -s -f -L "$download_url" -o "$temp_dir/$asset_name"; then
+    print_red "Error: Failed to download release asset for ref '$REF'"
+    print_red "Expected GitHub Release asset: $asset_name"
+    print_red "Hint: Create the release using ./release-comphy-tag.sh"
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+
+  if ! tar xzf "$temp_dir/$asset_name" -C "$temp_dir"; then
+    print_red "Error: Failed to extract downloaded tarball"
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+
+  if [[ ! -d "$temp_dir/basilisk/src" ]]; then
+    print_red "Error: Tarball is missing expected basilisk/src directory"
+    print_red "Expected tarball layout: basilisk/ and patches/ at top-level"
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+
+  print_cyan "Setting up basilisk directory..."
+  if ! mv "$temp_dir/basilisk" "$BASILISK_DIR"; then
+    print_red "Error: Failed to move basilisk into $BASILISK_DIR"
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+
+  patches_dest=""
+  if [[ -d "$temp_dir/patches" ]]; then
+    if [[ ! -d "$PATCHES_DIR" ]]; then
+      if ! mv "$temp_dir/patches" "$PATCHES_DIR"; then
+        print_red "Error: Failed to move patches into $PATCHES_DIR"
+        rm -rf "$temp_dir"
+        exit 1
+      fi
+      patches_dest="$PATCHES_DIR"
+    else
+      patches_dest="$BASILISK_DIR/.comphy-patches"
+      if ! mv "$temp_dir/patches" "$patches_dest"; then
+        print_red "Error: Failed to move patches into $patches_dest"
+        rm -rf "$temp_dir"
+        exit 1
+      fi
+    fi
+  else
+    print_red "Error: Tarball is missing expected patches/ directory"
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+
+  if [[ "$LOCAL_BVIEW" == true ]]; then
+    print_cyan "Applying local-bview patch (from pinned ref)..."
+
+    patches_api_url_ref="${PATCHES_API_URL}?ref=${REF}"
+    raw_base_url="https://raw.githubusercontent.com/comphy-lab/basilisk-C/${REF}/patches"
+    patch_file="$(curl -s "$patches_api_url_ref" | grep -o '\"name\": \"[^\"]*\.patch\"' | sed 's/\"name\": \"//;s/\"//' | grep -E -- '-local-bview\.patch$' | head -n 1)"
+
+    if [[ -z "$patch_file" ]]; then
+      print_red "Error: Could not find a *-local-bview.patch file at ref '$REF'"
+      rm -rf "$temp_dir"
+      exit 1
+    fi
+
+    if ! curl -s -f -L "$raw_base_url/$patch_file" -o "$patches_dest/$patch_file"; then
+      print_red "Error: Failed to download $patch_file from pinned ref"
+      rm -rf "$temp_dir"
+      exit 1
+    fi
+
+    if ! (cd "$BASILISK_DIR" && patch -p1 < "$patches_dest/$patch_file"); then
+      print_red "Error: Failed to apply $patch_file"
+      rm -rf "$temp_dir"
+      exit 1
+    fi
+  fi
+
+  write_lock_stamp "$LOCK_FILE" "$REF" "$patches_dest" "$LOCAL_BVIEW"
+  rm -rf "$temp_dir"
+
+  build_basilisk
+else
+  print_cyan "Using existing basilisk installation..."
+
+  local_lock_ref="$(read_lock_ref "$LOCK_FILE")"
+  if [[ -z "$local_lock_ref" ]]; then
+    print_red "Error: Existing $BASILISK_DIR is not ref-locked (missing .comphy-lock)."
+    print_red "Run with --hard (or remove $BASILISK_DIR) to install ref-locked."
+    exit 1
+  fi
+  if [[ "$local_lock_ref" != "$REF" ]]; then
+    print_red "Error: Existing $BASILISK_DIR is locked to ref '$local_lock_ref' but you requested '$REF'."
+    print_red "Run with --hard to reinstall the requested ref."
+    exit 1
+  fi
+
+  if [[ ! -d "$BASILISK_SRC_DIR" ]]; then
+    print_red "Error: Missing $BASILISK_SRC_DIR. Run with --hard to reinstall."
+    exit 1
+  fi
+fi
+
+write_project_config "$PROJECT_CONFIG" "$BASILISK_SRC_DIR"
+source "$PROJECT_CONFIG"
+verify_installation
+
+echo ""
+print_green "✅ Basilisk ref-locked installation complete!"
+echo "To use basilisk in your shell, run:"
+echo "  source $PROJECT_CONFIG"
+echo "Lock stamp:"
+echo "  $LOCK_FILE"

--- a/reset_install_basilisk-ref-locked.sh
+++ b/reset_install_basilisk-ref-locked.sh
@@ -52,15 +52,19 @@ Usage:
 Options:
   --help, -h      Show this help message
   --hard          Force reinstall (removes existing basilisk directory)
-  --local-bview   Apply the local-bview patch for localhost JavaScript client
+  --local-bview   Apply optional local-bview convenience patch (enables `bview --local` URL output for bview-local-client)
   --ref=REF       Required. GitHub Release tag in comphy-lab/basilisk-C
 
 Examples:
   ./reset_install_basilisk-ref-locked.sh --ref=v2026-01-13 --hard
+  ./reset_install_basilisk-ref-locked.sh --ref=v2026-01-13 --local-bview --hard
 
 Remote:
   curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | bash -s -- --ref=v2026-01-13 --hard
   curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | zsh  -s -- --ref=v2026-01-13 --hard
+
+Notes:
+  - GitHub Release tarballs intentionally exclude the local-bview patch; `--local-bview` downloads and applies it for the same `--ref`.
 EOF
 }
 

--- a/reset_install_basilisk.sh
+++ b/reset_install_basilisk.sh
@@ -64,7 +64,7 @@ Usage: ./reset_install_basilisk.sh [OPTIONS]
 Options:
   --help, -h      Show this help message
   --hard          Force reinstall (removes existing basilisk directory)
-  --local-bview   Apply the local-bview patch for localhost JavaScript client
+  --local-bview   Apply optional local-bview convenience patch (enables `bview --local` URL output for bview-local-client)
   --mode=N        Select installation mode non-interactively (1-4)
   --ref=REF       Pinned tag (release) for mode 4 only
 
@@ -91,6 +91,11 @@ Examples:
   ./reset_install_basilisk.sh --mode=2 --hard    # Reinstall using wget
   ./reset_install_basilisk.sh --mode=1 --local-bview  # Include local-bview patch
   ./reset_install_basilisk.sh --mode=4 --ref=v2026-01-13 --hard  # Ref-locked install (from release assets)
+  ./reset_install_basilisk.sh --mode=4 --ref=v2026-01-13 --local-bview --hard  # Ref-locked + local-bview patch
+
+Notes:
+  - The local-bview patch is optional and not applied by default.
+  - GitHub Release tarballs intentionally exclude it; `--local-bview` downloads and applies the patch for the same `--ref`.
 
 For more information, visit: https://github.com/comphy-lab/basilisk-C
 EOF

--- a/reset_install_basilisk.sh
+++ b/reset_install_basilisk.sh
@@ -28,6 +28,7 @@ HARD_RESET=false
 LOCAL_BVIEW=false
 SHOW_HELP=false
 MODE=""
+REF=""
 
 for arg in "$@"; do
     case "$arg" in
@@ -42,6 +43,9 @@ for arg in "$@"; do
             ;;
         --mode=*)
             MODE="${arg#*=}"
+            ;;
+        --ref=*)
+            REF="${arg#*=}"
             ;;
     esac
 done
@@ -61,7 +65,8 @@ Options:
   --help, -h      Show this help message
   --hard          Force reinstall (removes existing basilisk directory)
   --local-bview   Apply the local-bview patch for localhost JavaScript client
-  --mode=N        Select installation mode non-interactively (1-3)
+  --mode=N        Select installation mode non-interactively (1-4)
+  --ref=REF       Pinned tag (release) for mode 4 only
 
 Installation Modes:
   1) default       - Use darcs to clone basilisk, fetch patches from GitHub
@@ -76,11 +81,16 @@ Installation Modes:
                      Best for: Quick setup without darcs
                      Requires: git, curl, gawk, make, gcc
 
+  4) ref-locked    - Install from OS-specific tarball attached to a GitHub Release tag
+                     Best for: Reproducible installs, HPC (no darcs/git)
+                     Requires: curl, tar, gawk, make, gcc
+
 Examples:
   ./reset_install_basilisk.sh                    # Interactive mode selection
   ./reset_install_basilisk.sh --mode=1           # Use default mode
   ./reset_install_basilisk.sh --mode=2 --hard    # Reinstall using wget
   ./reset_install_basilisk.sh --mode=1 --local-bview  # Include local-bview patch
+  ./reset_install_basilisk.sh --mode=4 --ref=v2026-01-13 --hard  # Ref-locked install (from release assets)
 
 For more information, visit: https://github.com/comphy-lab/basilisk-C
 EOF
@@ -128,6 +138,9 @@ show_install_instructions() {
             make|gcc)
                 echo "  xcode-select --install"
                 ;;
+            patch)
+                echo "  (patch should be pre-installed on macOS)"
+                ;;
             darcs)
                 echo "  brew install darcs"
                 ;;
@@ -151,6 +164,9 @@ show_install_instructions() {
         case "$tool" in
             make|gcc)
                 echo "  sudo apt install build-essential"
+                ;;
+            patch)
+                echo "  sudo apt install patch"
                 ;;
             darcs)
                 echo "  Visit https://darcs.net/ for installation instructions"
@@ -177,17 +193,28 @@ check_prerequisites() {
     case "$mode" in
         1)    # darcs mode
             check_tool "darcs" || missing_tools+=("darcs")
+            check_tool "patch" || missing_tools+=("patch")
             ;;
         2)    # wget mode
             check_tool "wget" || missing_tools+=("wget")
             check_tool "tar" || missing_tools+=("tar")
             check_tool "curl" || missing_tools+=("curl")
             check_tool "gawk" || missing_tools+=("gawk")
+            check_tool "patch" || missing_tools+=("patch")
             ;;
         3)    # git mode
             check_tool "git" || missing_tools+=("git")
             check_tool "curl" || missing_tools+=("curl")
             check_tool "gawk" || missing_tools+=("gawk")
+            check_tool "patch" || missing_tools+=("patch")
+            ;;
+        4)    # ref-locked mode
+            check_tool "curl" || missing_tools+=("curl")
+            check_tool "tar" || missing_tools+=("tar")
+            check_tool "gawk" || missing_tools+=("gawk")
+            if [[ "$LOCAL_BVIEW" == true ]]; then
+                check_tool "patch" || missing_tools+=("patch")
+            fi
             ;;
     esac
 
@@ -220,8 +247,9 @@ select_mode() {
     echo "  1) default       - darcs clone + GitHub patches (recommended)"
     echo "  2) remote-fr     - wget tarball + GitHub patches (no darcs needed)"
     echo "  3) remote-comphy - git clone from comphy-lab fork (no darcs needed)"
+    echo "  4) ref-locked    - pinned GitHub Release tag (reproducible)"
     echo ""
-    printf "Select mode [1-3, default=1]: "
+    printf "Select mode [1-4, default=1]: "
     read -r selection
 
     # Default to mode 1 if empty
@@ -231,7 +259,7 @@ select_mode() {
 
     # Validate selection
     case "$selection" in
-        1|2|3)
+        1|2|3|4)
             MODE="$selection"
             ;;
         *)
@@ -243,6 +271,121 @@ select_mode() {
     echo ""
     print_cyan "Selected mode: $MODE"
     echo ""
+
+    if [[ "$MODE" == "4" ]] && [[ -z "${REF}" ]]; then
+        printf "Enter GitHub Release tag for mode 4 (e.g. v2026-01-13): "
+        read -r REF
+        if [[ -z "${REF}" ]]; then
+            print_red "Error: --ref is required for mode 4"
+            exit 1
+        fi
+    fi
+}
+
+read_lock_ref() {
+    local lock_file="$1"
+    local lock_ref=""
+
+    if [[ ! -f "$lock_file" ]]; then
+        echo ""
+        return 0
+    fi
+
+    while IFS= read -r line; do
+        case "$line" in
+            ref=*)
+                lock_ref="${line#ref=}"
+                ;;
+        esac
+    done < "$lock_file"
+
+    echo "$lock_ref"
+}
+
+write_lock_stamp() {
+    local lock_file="$1"
+    local ref="$2"
+    local patches_dir="$3"
+    local apply_local_bview="$4"
+
+    local patch_files=()
+    local applied_patches=()
+    local skipped_patches=()
+
+    patch_files=($(ls "$patches_dir"/*.patch 2>/dev/null | sort))
+    for patch_file in "${patch_files[@]}"; do
+        local patch_name
+        patch_name=$(basename "$patch_file")
+
+        if [[ "$patch_name" == *"-local-bview.patch" ]] && [[ "$apply_local_bview" != "true" ]]; then
+            skipped_patches+=("$patch_name")
+            continue
+        fi
+        if [[ "$patch_name" == *"-macos-"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
+            skipped_patches+=("$patch_name")
+            continue
+        fi
+        applied_patches+=("$patch_name")
+    done
+
+    {
+        printf "ref=%s\n" "$ref"
+        printf "created_utc=%s\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date)"
+        printf "local_bview=%s\n" "$apply_local_bview"
+        printf "patches_applied=%s\n" "${applied_patches[*]}"
+        printf "patches_skipped=%s\n" "${skipped_patches[*]}"
+    } > "$lock_file"
+}
+
+apply_patches_from_dir() {
+    local target_dir="$1"
+    local patches_dir="$2"
+    local apply_local_bview="${3:-false}"
+    local patch_failed=false
+
+    print_cyan "Applying comphy-lab patches (from pinned ref)..."
+
+    if [[ ! -d "$patches_dir" ]]; then
+        print_red "Error: Missing patches directory: $patches_dir"
+        return 1
+    fi
+
+    local patch_files
+    patch_files=($(ls "$patches_dir"/*.patch 2>/dev/null | sort))
+
+    if [[ ${#patch_files[@]} -eq 0 ]]; then
+        print_yellow "Warning: No patches found in $patches_dir"
+        return 0
+    fi
+
+    for patch_file in "${patch_files[@]}"; do
+        local patch_name
+        patch_name=$(basename "$patch_file")
+
+        if [[ "$patch_name" == *"-local-bview.patch" ]] && [[ "$apply_local_bview" != "true" ]]; then
+            echo "  Skipping $patch_name (use --local-bview to apply)"
+            continue
+        fi
+        if [[ "$patch_name" == *"-macos-"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
+            echo "  Skipping $patch_name (macOS-specific patch)"
+            continue
+        fi
+
+        echo "  Applying $patch_name..."
+        if (cd "$target_dir" && patch -p1 < "$patch_file"); then
+            print_green "  ✓ Successfully applied $patch_name"
+        else
+            print_red "  ✗ Failed to apply $patch_name"
+            patch_failed=true
+        fi
+    done
+
+    echo ""
+
+    if [[ "$patch_failed" == true ]]; then
+        return 1
+    fi
+    return 0
 }
 
 # ============================================================================
@@ -423,6 +566,114 @@ install_basilisk_git() {
     rm -rf "$TEMP_DIR"
 }
 
+install_basilisk_ref_locked() {
+    local ref="$1"
+    local lock_file="$2"
+
+    local asset_name
+    local download_url
+    local temp_dir
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        asset_name="basilisk-mac.tar.gz"
+    else
+        asset_name="basilisk-linux.tar.gz"
+    fi
+
+    download_url="https://github.com/comphy-lab/basilisk-C/releases/download/${ref}/${asset_name}"
+
+    print_cyan "Installing Basilisk from ref-locked release: $ref"
+    print_cyan "Downloading: $download_url"
+
+    temp_dir="$(mktemp -d 2>/dev/null || mktemp -d -t basilisk-C)"
+    if [[ -z "$temp_dir" ]] || [[ ! -d "$temp_dir" ]]; then
+        print_red "Error: Failed to create temp directory"
+        exit 1
+    fi
+
+    if ! curl -s -f -L "$download_url" -o "$temp_dir/$asset_name"; then
+        print_red "Error: Failed to download release asset for ref '$ref'"
+        print_red "Expected GitHub Release asset: $asset_name"
+        print_red "Hint: Create the release using ./release-comphy-tag.sh"
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+
+    if ! tar xzf "$temp_dir/$asset_name" -C "$temp_dir"; then
+        print_red "Error: Failed to extract downloaded tarball"
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+
+    if [[ ! -d "$temp_dir/basilisk/src" ]]; then
+        print_red "Error: Tarball is missing expected basilisk/src directory"
+        print_red "Expected tarball layout: basilisk/ and patches/ at top-level"
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+
+    print_cyan "Setting up basilisk directory..."
+    if ! mv "$temp_dir/basilisk" "$BASILISK_DIR"; then
+        print_red "Error: Failed to move basilisk into $BASILISK_DIR"
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+
+    local patches_dest=""
+    if [[ -d "$temp_dir/patches" ]]; then
+        if [[ ! -d "$PATCHES_DIR" ]]; then
+            if ! mv "$temp_dir/patches" "$PATCHES_DIR"; then
+                print_red "Error: Failed to move patches into $PATCHES_DIR"
+                rm -rf "$temp_dir"
+                exit 1
+            fi
+            patches_dest="$PATCHES_DIR"
+        else
+            patches_dest="$BASILISK_DIR/.comphy-patches"
+            if ! mv "$temp_dir/patches" "$patches_dest"; then
+                print_red "Error: Failed to move patches into $patches_dest"
+                rm -rf "$temp_dir"
+                exit 1
+            fi
+        fi
+    else
+        print_red "Error: Tarball is missing expected patches/ directory"
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+
+    if [[ "$LOCAL_BVIEW" == true ]]; then
+        print_cyan "Applying local-bview patch (from pinned ref)..."
+
+        local patches_api_url_ref="${PATCHES_API_URL}?ref=${ref}"
+        local raw_base_url="https://raw.githubusercontent.com/comphy-lab/basilisk-C/${ref}/patches"
+        local patch_file
+        patch_file="$(curl -s "$patches_api_url_ref" | grep -o '\"name\": \"[^\"]*\.patch\"' | sed 's/\"name\": \"//;s/\"//' | grep -E -- '-local-bview\.patch$' | head -n 1)"
+
+        if [[ -z "$patch_file" ]]; then
+            print_red "Error: Could not find a *-local-bview.patch file at ref '$ref'"
+            rm -rf "$temp_dir"
+            exit 1
+        fi
+
+        if ! curl -s -f -L "$raw_base_url/$patch_file" -o "$patches_dest/$patch_file"; then
+            print_red "Error: Failed to download $patch_file from pinned ref"
+            rm -rf "$temp_dir"
+            exit 1
+        fi
+
+        if ! (cd "$BASILISK_DIR" && patch -p1 < "$patches_dest/$patch_file"); then
+            print_red "Error: Failed to apply $patch_file"
+            rm -rf "$temp_dir"
+            exit 1
+        fi
+    fi
+
+    write_lock_stamp "$lock_file" "$ref" "$patches_dest" "$LOCAL_BVIEW"
+
+    rm -rf "$temp_dir"
+}
+
 # ============================================================================
 # Build function
 # ============================================================================
@@ -465,9 +716,28 @@ setup_environment() {
         exit 1
     fi
 
-    printf "export BASILISK=%s\n" "$BASILISK_SRC_DIR" > "$PROJECT_CONFIG"
-    # Prepend BASILISK to PATH so Basilisk tools (qcc, etc.) take precedence
-    printf "export PATH=\$BASILISK:\$PATH\n" >> "$PROJECT_CONFIG"
+    {
+        printf 'export BASILISK="%s"\n' "$BASILISK_SRC_DIR"
+        cat <<'EOF'
+
+if [ ! -d "$BASILISK" ]; then
+  echo "Error: BASILISK directory not found: $BASILISK" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Ensure the repo-installed Basilisk takes precedence, without duplicating PATH
+_PATH=":$PATH:"
+_PATH="${_PATH//:$BASILISK:/:}"
+_PATH="${_PATH#:}"
+_PATH="${_PATH%:}"
+export PATH="$BASILISK${_PATH:+:$_PATH}"
+unset _PATH
+
+# Refresh command lookup cache (best-effort)
+hash -r 2>/dev/null || true
+rehash 2>/dev/null || true
+EOF
+    } > "$PROJECT_CONFIG"
 
     source "$PROJECT_CONFIG"
 }
@@ -475,6 +745,27 @@ setup_environment() {
 verify_installation() {
     echo ""
     print_cyan "Checking qcc installation..."
+
+    local qcc_path
+    qcc_path="$(command -v qcc 2>/dev/null || true)"
+
+    if [[ -z "$qcc_path" ]]; then
+        print_red "Error: qcc not found on PATH after sourcing .project_config"
+        exit 1
+    fi
+
+    if [[ "$qcc_path" != /* ]]; then
+        print_red "Error: qcc resolves to a non-path ('$qcc_path'). This is likely an alias/function."
+        print_red "Remove/disable the alias/function and try again."
+        exit 1
+    fi
+
+    if [[ "$qcc_path" != "$BASILISK/"* ]]; then
+        print_red "Error: qcc resolves to '$qcc_path' but expected it under '$BASILISK/'."
+        print_red "This usually means a global Basilisk install is taking precedence."
+        print_red "Try: 'hash -r' (bash) or 'rehash' (zsh), then re-source .project_config."
+        exit 1
+    fi
 
     if ! qcc --version > /dev/null 2>&1; then
         print_red "Error: qcc is not working properly."
@@ -510,13 +801,18 @@ fi
 
 # Validate mode
 case "$MODE" in
-    1|2|3)
+    1|2|3|4)
         ;;
     *)
-        print_red "Invalid mode: $MODE (must be 1-3)"
+        print_red "Invalid mode: $MODE (must be 1-4)"
         exit 1
         ;;
 esac
+
+if [[ "$MODE" == "4" ]] && [[ -z "${REF}" ]]; then
+    print_red "Error: --ref is required for mode 4"
+    exit 1
+fi
 
 # Check prerequisites for selected mode
 check_prerequisites "$MODE"
@@ -551,11 +847,27 @@ if [[ "$HARD_RESET" == true ]] || [[ ! -d "$BASILISK_DIR" ]]; then
                 exit 1
             fi
             ;;
+        4)  # ref-locked: pinned comphy-lab/basilisk-C ref
+            install_basilisk_ref_locked "$REF" "$BASILISK_DIR/.comphy-lock"
+            ;;
     esac
 
     build_basilisk
 else
     print_cyan "Using existing basilisk installation..."
+    if [[ "$MODE" == "4" ]]; then
+        local_lock_ref="$(read_lock_ref "$BASILISK_DIR/.comphy-lock")"
+        if [[ -z "$local_lock_ref" ]]; then
+            print_red "Error: Existing $BASILISK_DIR is not ref-locked (missing .comphy-lock)."
+            print_red "Run with --hard (or remove $BASILISK_DIR) to install ref-locked."
+            exit 1
+        fi
+        if [[ "$local_lock_ref" != "$REF" ]]; then
+            print_red "Error: Existing $BASILISK_DIR is locked to ref '$local_lock_ref' but you requested '$REF'."
+            print_red "Run with --hard to reinstall the requested ref."
+            exit 1
+        fi
+    fi
     if [[ ! -d "$BASILISK_SRC_DIR" ]]; then
         print_red "Error: Missing $BASILISK_SRC_DIR. Run with --hard to reinstall."
         exit 1
@@ -570,3 +882,7 @@ echo ""
 print_green "✅ Basilisk installation complete!"
 echo "To use basilisk in your shell, run:"
 echo "  source $PROJECT_CONFIG"
+if [[ "$MODE" == "4" ]]; then
+    echo "Lock stamp:"
+    echo "  $BASILISK_DIR/.comphy-lock"
+fi

--- a/reset_install_requirements-darcs.sh
+++ b/reset_install_requirements-darcs.sh
@@ -11,5 +11,5 @@ if [[ -f "$NEW_SCRIPT" ]]; then
     exec "$NEW_SCRIPT" "$@"
 else
     # Remote execution (curl | bash) - fetch the new script
-    exec bash <(curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-darcs.sh) "$@"
+    curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-darcs.sh | bash -s -- "$@"
 fi

--- a/reset_install_requirements-no-darcs-no-git.sh
+++ b/reset_install_requirements-no-darcs-no-git.sh
@@ -11,5 +11,5 @@ if [[ -f "$NEW_SCRIPT" ]]; then
     exec "$NEW_SCRIPT" "$@"
 else
     # Remote execution (curl | bash) - fetch the new script
-    exec bash <(curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-no-darcs-no-git.sh) "$@"
+    curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-no-darcs-no-git.sh | bash -s -- "$@"
 fi

--- a/reset_install_requirements-no-darcs.sh
+++ b/reset_install_requirements-no-darcs.sh
@@ -11,5 +11,5 @@ if [[ -f "$NEW_SCRIPT" ]]; then
     exec "$NEW_SCRIPT" "$@"
 else
     # Remote execution (curl | bash) - fetch the new script
-    exec bash <(curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-no-darcs.sh) "$@"
+    curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-no-darcs.sh | bash -s -- "$@"
 fi

--- a/reset_install_requirements.sh
+++ b/reset_install_requirements.sh
@@ -11,5 +11,5 @@ if [[ -f "$NEW_SCRIPT" ]]; then
     exec "$NEW_SCRIPT" "$@"
 else
     # Remote execution (curl | bash) - fetch the new script
-    exec bash <(curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk.sh) "$@"
+    curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk.sh | bash -s -- "$@"
 fi


### PR DESCRIPTION
## Summary
- Add automated release workflow for creating tagged Basilisk releases with OS-specific tarballs
- Enhance install scripts with version locking capability for reproducible installations
- Update bview local patch documentation to clarify it's optional/aesthetic

## Changes Made

### New: Release Tooling (`release-comphy-tag.sh`)
- Creates tagged releases (vYYYY-MM-DD format) with automated GitHub Release publishing
- Produces OS-specific tarballs: `basilisk-mac.tar.gz` and `basilisk-linux.tar.gz`
- Applies appropriate patches per platform (excludes local-bview patch from release tarballs)
- Includes install tests: native testing + Docker-based cross-platform validation on macOS

### Enhanced: Install Scripts
- Add `--ref=TAG` support to all install variants for version-locked installations
- New `reset_install_basilisk-ref-locked.sh` for installing from GitHub Release tarballs
- Ref-locked installs skip darcs entirely, using pre-patched tarballs for faster setup
- Optional `--local-bview` flag to apply the local-bview patch during ref-locked installs

### Documentation Updates
- `patches/README.md`: Clarify local-bview patch is aesthetic/optional
- `Tips.md`: Add comprehensive installation documentation
- `README.md`: Minor updates

## Testing
- Install scripts tested on macOS with native and Docker-based Linux validation
- Release script includes built-in test suite with `--skip-tests` option for CI