### PR TITLE
Add comphy-bview patch: loopback-bound bview binaries with runtime-configurable URLs

### DIFF
--- a/patches/2026-08-14-comphy-bview.patch
+++ b/patches/2026-08-14-comphy-bview.patch
@@ -27,6 +27,7 @@
 #   * binds DISPLAY_HOST, defaulting to 127.0.0.1 rather than every interface;
 #   * defaults the client URL to http://localhost:8000/three.js/editor/index.html
 #     (see github.com/comphy-lab/bview-local-client);
+#   * reads BVIEW_BIND_HOST to override the bind address at runtime;
 #   * reads BVIEW_CLIENT_URL and BVIEW_WS_TEMPLATE at runtime, so a deployment
 #     address never has to be compiled in. {port} in BVIEW_WS_TEMPLATE expands
 #     to the port actually bound.
@@ -35,8 +36,13 @@
 # upstream URL. ws_socket_open() keeps its signature and its all-interfaces
 # behaviour; the new ws_socket_open_on() takes an explicit bind address.
 #
-# To restore all-interfaces listening in a comphy build:
-#   qcc -DCOMPHY_BVIEW -DDISPLAY_HOST='"0.0.0.0"' ...
+# To listen on every interface instead, set BVIEW_BIND_HOST at runtime:
+#   BVIEW_BIND_HOST=0.0.0.0 bview-comphy2D dump
+#
+# The bind address and the advertised address are distinct. 0.0.0.0 means
+# "every interface" and is not connectable, so it is never printed: the URL
+# falls back to localhost. For genuine cross-machine access set
+# BVIEW_WS_TEMPLATE to the address clients should really use.
 #
 # Example:
 #   export BVIEW_CLIENT_URL='https://example.internal/three.js/editor/index.html'
@@ -53,8 +59,8 @@
 #
 diff -rN -u old-basilisk/src/display.h new-basilisk/src/display.h
 --- old-basilisk/src/display.h	2026-08-14 16:46:22.228922798 +0100
-+++ new-basilisk/src/display.h	2026-08-14 16:47:40.847647750 +0100
-@@ -66,11 +66,39 @@
++++ new-basilisk/src/display.h	2026-08-14 18:35:03.663464311 +0100
+@@ -66,11 +66,69 @@
  */
  
  #ifndef DISPLAY_JS
@@ -93,10 +99,40 @@ diff -rN -u old-basilisk/src/display.h new-basilisk/src/display.h
 +# else
 +#  define DISPLAY_HOST "localhost"
 +# endif
++#endif
++
++#ifdef COMPHY_BVIEW
++
++/**
++The address to bind. DISPLAY_HOST is the compile-time default; BVIEW_BIND_HOST
++overrides it at runtime. Use `BVIEW_BIND_HOST=0.0.0.0` to listen on every
++interface, bearing in mind that the protocol is unauthenticated and that any
++peer able to reach the port can drive the drawing-command interpreter.
++*/
++static const char * display_bind_host (void)
++{
++  const char * h = getenv ("BVIEW_BIND_HOST");
++  return (h && *h) ? h : DISPLAY_HOST;
++}
++
++/**
++The address to advertise, which is not the same thing. 0.0.0.0 means "every
++interface" and is not something a client can connect to, so it must never
++appear in the printed URL; fall back to localhost. For genuine cross-machine
++access set BVIEW_WS_TEMPLATE to the address clients should really use.
++*/
++static const char * display_advertised_host (void)
++{
++  const char * h = display_bind_host();
++  if (!h || !*h || !strcmp (h, "0.0.0.0") || !strcmp (h, "::"))
++    return "localhost";
++  return h;
++}
++
  #endif
  
  #ifndef DISPLAY_RANGE
-@@ -692,8 +720,44 @@
+@@ -692,8 +750,44 @@
    return nmsg;
  }
  
@@ -106,7 +142,7 @@ diff -rN -u old-basilisk/src/display.h new-basilisk/src/display.h
 +static int display_socket_open (uint16_t port)
 +{
 +#ifdef COMPHY_BVIEW
-+  return ws_socket_open_on (DISPLAY_HOST, port);
++  return ws_socket_open_on (display_bind_host(), port);
 +#else
 +  return ws_socket_open (port);
 +#endif
@@ -134,14 +170,14 @@ diff -rN -u old-basilisk/src/display.h new-basilisk/src/display.h
 +    }
 +  }
 +  else
-+    fprintf (fp, "ws://%s:%d", DISPLAY_HOST, Display.port);
++    fprintf (fp, "ws://%s:%d", display_advertised_host(), Display.port);
 +
 +#else // !COMPHY_BVIEW
 +
    char hostname[1024];
    hostname[1023] = '\0';
    gethostname (hostname, 1023);
-@@ -704,6 +768,8 @@
+@@ -704,6 +798,8 @@
  	     LINENO, hostname);
    fprintf (fp, DISPLAY_JS "?ws://%s:%d", h ? h->h_name : "127.0.0.1",
  	   Display.port);
@@ -150,7 +186,7 @@ diff -rN -u old-basilisk/src/display.h new-basilisk/src/display.h
  }
  
  int display_usage = 20; // use 20% of runtime, maximum
-@@ -746,14 +812,14 @@
+@@ -746,14 +842,14 @@
    if (pid() == 0) {
      const char * port = DISPLAY_RANGE;
      if (!strchr (port, ':'))

--- a/patches/2026-08-14-comphy-bview.patch
+++ b/patches/2026-08-14-comphy-bview.patch
@@ -1,0 +1,260 @@
+# Patch: comphy-bview
+# Author: Vatsal Sanjay <vatsal.sanjay@comphy-lab.org>
+# Date: 2026-08-14
+# Description: Adds bview-comphy2D/3D, which bind loopback by default and take
+#              their client and websocket URLs from the environment.
+#
+# Upstream bview serves two purposes that are hard to separate: it is the
+# visualisation server, and it advertises where the javascript client lives.
+# The client URL is fixed at compile time (basilisk.ida.upmc.fr), and the
+# server binds every interface with no way to change it -- src/display.h
+# defines DISPLAY_HOST and then never uses it, while wsServer hardcodes
+# INADDR_ANY.
+#
+# That second point matters. The websocket protocol carries no authentication,
+# and display_onmessage() passes client text straight to process_line(), which
+# interprets drawing commands inside the running solver. Any peer able to reach
+# the port can therefore drive that interpreter. Upstream's own documentation
+# assumes an SSH tunnel, which implies a loopback listener, but the code does
+# not enforce it.
+#
+# This patch adds two new binaries rather than changing the existing ones:
+#
+#   bview-comphy2D, bview-comphy3D
+#
+# They are built from the same src/bview.c with -DCOMPHY_BVIEW, which:
+#
+#   * binds DISPLAY_HOST, defaulting to 127.0.0.1 rather than every interface;
+#   * defaults the client URL to http://localhost:8000/three.js/editor/index.html
+#     (see github.com/comphy-lab/bview-local-client);
+#   * reads BVIEW_CLIENT_URL and BVIEW_WS_TEMPLATE at runtime, so a deployment
+#     address never has to be compiled in. {port} in BVIEW_WS_TEMPLATE expands
+#     to the port actually bound.
+#
+# bview2D, bview3D and bview2Dm are unchanged in behaviour and still print the
+# upstream URL. ws_socket_open() keeps its signature and its all-interfaces
+# behaviour; the new ws_socket_open_on() takes an explicit bind address.
+#
+# To restore all-interfaces listening in a comphy build:
+#   qcc -DCOMPHY_BVIEW -DDISPLAY_HOST='"0.0.0.0"' ...
+#
+# Example:
+#   export BVIEW_CLIENT_URL='https://example.internal/three.js/editor/index.html'
+#   export BVIEW_WS_TEMPLATE='wss://example.internal:{port}'
+#   bview-comphy2D dump
+#
+# Note: GitHub Release tarballs intentionally exclude this patch.
+#       Enable via installer flag: --comphy-bview
+#
+# Related: https://github.com/comphy-lab/bview-local-client
+# Platform: All
+# Files: src/display.h, src/Makefile, src/wsServer/src/ws.c,
+#        src/wsServer/include/ws.h
+#
+diff -rN -u old-basilisk/src/display.h new-basilisk/src/display.h
+--- old-basilisk/src/display.h	2026-08-14 16:46:22.228922798 +0100
++++ new-basilisk/src/display.h	2026-08-14 16:47:40.847647750 +0100
+@@ -66,11 +66,39 @@
+ */
+ 
+ #ifndef DISPLAY_JS
+-# define DISPLAY_JS "http://basilisk.ida.upmc.fr/three.js/editor/index.html"
++# ifdef COMPHY_BVIEW
++/**
++The comphy-lab build defaults to a locally-served client rather than the
++upstream one. Both halves of the printed URL can be overridden at runtime
++through the environment, so the deployment address never has to be compiled
++in:
++
++* `BVIEW_CLIENT_URL`  where the javascript client is served from;
++* `BVIEW_WS_TEMPLATE` the websocket address, where `{port}` is replaced by
++  the port this server actually bound.
++*/
++#  define DISPLAY_JS "http://localhost:8000/three.js/editor/index.html"
++# else
++#  define DISPLAY_JS "http://basilisk.ida.upmc.fr/three.js/editor/index.html"
++# endif
+ #endif
+ 
+ #ifndef DISPLAY_HOST
+-# define DISPLAY_HOST "localhost"
++# ifdef COMPHY_BVIEW
++/**
++Upstream defines DISPLAY_HOST but never uses it, so the server always binds
++every interface. The comphy-lab build binds the loopback address instead: the
++websocket protocol carries no authentication, and any peer able to reach the
++port can drive the drawing-command interpreter inside the running solver.
++Cross-machine access should be arranged deliberately, by an SSH tunnel or a
++reverse proxy, rather than by listening on every interface by default.
++
++Compile with -DDISPLAY_HOST='"0.0.0.0"' to restore the upstream behaviour.
++*/
++#  define DISPLAY_HOST "127.0.0.1"
++# else
++#  define DISPLAY_HOST "localhost"
++# endif
+ #endif
+ 
+ #ifndef DISPLAY_RANGE
+@@ -692,8 +720,44 @@
+   return nmsg;
+ }
+ 
++/**
++Opens the display socket, honouring DISPLAY_HOST where the build supports it.
++*/
++static int display_socket_open (uint16_t port)
++{
++#ifdef COMPHY_BVIEW
++  return ws_socket_open_on (DISPLAY_HOST, port);
++#else
++  return ws_socket_open (port);
++#endif
++}
++
+ void display_url (FILE * fp)
+ {
++#ifdef COMPHY_BVIEW
++
++  /**
++  Both halves of the URL are independently overridable, so a deployment
++  address is never compiled in. `{port}` in BVIEW_WS_TEMPLATE expands to the
++  port actually bound, which is not known until display_init() has run. */
++
++  const char * client = getenv ("BVIEW_CLIENT_URL");
++  const char * wstmpl = getenv ("BVIEW_WS_TEMPLATE");
++  fputs (client && *client ? client : DISPLAY_JS, fp);
++  fputc ('?', fp);
++  if (wstmpl && *wstmpl) {
++    for (const char * q = wstmpl; *q;) {
++      if (!strncmp (q, "{port}", 6))
++	fprintf (fp, "%d", Display.port), q += 6;
++      else
++	fputc (*q++, fp);
++    }
++  }
++  else
++    fprintf (fp, "ws://%s:%d", DISPLAY_HOST, Display.port);
++
++#else // !COMPHY_BVIEW
++
+   char hostname[1024];
+   hostname[1023] = '\0';
+   gethostname (hostname, 1023);
+@@ -704,6 +768,8 @@
+ 	     LINENO, hostname);
+   fprintf (fp, DISPLAY_JS "?ws://%s:%d", h ? h->h_name : "127.0.0.1",
+ 	   Display.port);
++
++#endif
+ }
+ 
+ int display_usage = 20; // use 20% of runtime, maximum
+@@ -746,14 +812,14 @@
+   if (pid() == 0) {
+     const char * port = DISPLAY_RANGE;
+     if (!strchr (port, ':'))
+-      Display.sock = ws_socket_open (atoi (port));
++      Display.sock = display_socket_open (atoi (port));
+     else {
+       char * s = strdup (port);
+       char * s1 = strchr (s, ':');
+       *s1++ = '\0';
+       int pmax = atoi(s1);
+       Display.port = atoi(s);
+-      while ((Display.sock = ws_socket_open (Display.port)) < 0 &&
++      while ((Display.sock = display_socket_open (Display.port)) < 0 &&
+ 	     Display.port < pmax)
+ 	Display.port++;
+       free (s);
+diff -rN -u old-basilisk/src/Makefile new-basilisk/src/Makefile
+--- old-basilisk/src/Makefile	2026-08-14 16:46:22.231123931 +0100
++++ new-basilisk/src/Makefile	2026-08-14 16:48:05.562031002 +0100
+@@ -11,7 +11,8 @@
+ 
+ .PHONY: subdirs $(SUBDIRS) $(TOPTARGETS)
+ 
+-all: subdirs qcc literatec bview2D bview3D bview2Dm
++all: subdirs qcc literatec bview2D bview3D bview2Dm \
++	bview-comphy2D bview-comphy3D
+ 	@chmod +x ppm2mpeg ppm2mp4 ppm2ogv ppm2gif runtest page2html
+ 	@test -f xyz2kdt || ln -s kdt/xyz2kdt
+ 	@test -f kdtquery || ln -s kdt/kdtquery
+@@ -63,6 +64,16 @@
+ bview2Dm: bview.c
+ 	./qcc $(CFLAGS) -autolink -grid=multigrid bview.c -o bview2Dm -lfb_tiny -lm
+ 
++# comphy-lab variants. Same source, built with -DCOMPHY_BVIEW so they bind
++# DISPLAY_HOST (loopback by default) and take their client and websocket
++# URLs from BVIEW_CLIENT_URL and BVIEW_WS_TEMPLATE. The stock bview2D,
++# bview3D and bview2Dm above are untouched.
++bview-comphy2D: bview.c
++	./qcc $(CFLAGS) -DCOMPHY_BVIEW -autolink bview.c -o bview-comphy2D -lfb_tiny -lm
++
++bview-comphy3D: bview.c
++	./qcc $(CFLAGS) -DCOMPHY_BVIEW -autolink -grid=octree bview.c -o bview-comphy3D -lfb_tiny -lm
++
+ alltags:
+ 	cd navier-stokes && $(MAKE) tags
+ 	cd layered && $(MAKE) tags
+diff -rN -u old-basilisk/src/wsServer/include/ws.h new-basilisk/src/wsServer/include/ws.h
+--- old-basilisk/src/wsServer/include/ws.h	2026-08-14 16:46:22.235474768 +0100
++++ new-basilisk/src/wsServer/include/ws.h	2026-08-14 16:46:59.730285260 +0100
+@@ -225,6 +225,7 @@
+ 
+ 	/* Forward declarations. */
+         extern int ws_socket_open (uint16_t port);
++        extern int ws_socket_open_on (const char *bindaddr, uint16_t port);
+ 	extern int get_handshake_accept(char *wsKey, unsigned char **dest);
+ 	extern int get_handshake_response(char *hsrequest, char **hsresponse);
+ 	extern char *ws_getaddress(int fd);
+diff -rN -u old-basilisk/src/wsServer/src/ws.c new-basilisk/src/wsServer/src/ws.c
+--- old-basilisk/src/wsServer/src/ws.c	2026-08-14 16:46:22.233294287 +0100
++++ new-basilisk/src/wsServer/src/ws.c	2026-08-14 16:46:59.730619912 +0100
+@@ -1231,7 +1231,7 @@
+  *
+  * @return the socket.
+  */
+-int ws_socket_open (uint16_t port)
++int ws_socket_open_on (const char *bindaddr, uint16_t port)
+ {
+ 	int sock;                  /* Current socket.        */
+ 	struct sockaddr_in server; /* Server.                */
+@@ -1247,7 +1247,14 @@
+ 
+ 	/* Prepare the sockaddr_in structure. */
+ 	server.sin_family      = AF_INET;
+-	server.sin_addr.s_addr = INADDR_ANY;
++	if (bindaddr && *bindaddr) {
++		if (inet_pton(AF_INET, bindaddr, &server.sin_addr) != 1) {
++			close(sock);
++			return -1;
++		}
++	}
++	else
++		server.sin_addr.s_addr = INADDR_ANY;
+ 	server.sin_port        = htons(port);
+ 
+ 	/* Bind. */
+@@ -1265,6 +1272,21 @@
+ }
+ 
+ /**
++ * @brief Opens a listening socket on every interface.
++ *
++ * Retained unchanged for source compatibility. New code should prefer
++ * ws_socket_open_on() with an explicit bind address.
++ *
++ * @param port Port to listen on.
++ *
++ * @return The socket, or -1 on failure.
++ */
++int ws_socket_open (uint16_t port)
++{
++	return ws_socket_open_on(NULL, port);
++}
++
++/**
+  * @brief Polls a WebSocket.
+  *
+  * @param sock The WebSocket (as returned by ws_socket_open()).

--- a/patches/README.md
+++ b/patches/README.md
@@ -152,6 +152,15 @@ behind a proxy that terminates TLS:
 export BVIEW_WS_TEMPLATE='wss://example.internal:{port}'
 ```
 
+`{port}` expands to the port the bview server actually bound, so this form is
+only correct when the proxy exposes that same port externally — as a
+port-preserving TLS terminator does. Where the external port differs, write it
+literally instead:
+
+```shell
+export BVIEW_WS_TEMPLATE='wss://example.internal:8443'
+```
+
 **wsServer compatibility:** `ws_socket_open()` keeps its signature and its
 all-interfaces behaviour. The patch adds `ws_socket_open_on(bindaddr, port)`
 alongside it, so nothing else linking against wsServer is affected.

--- a/patches/README.md
+++ b/patches/README.md
@@ -119,7 +119,8 @@ same `src/bview.c` with `-DCOMPHY_BVIEW`. The stock `bview2D`, `bview3D` and
   | Variable | Meaning | Default |
   |---|---|---|
   | `BVIEW_CLIENT_URL` | where the javascript client is served from | `http://localhost:8000/three.js/editor/index.html` |
-  | `BVIEW_WS_TEMPLATE` | websocket address; `{port}` expands to the bound port | `ws://<DISPLAY_HOST>:<port>` |
+  | `BVIEW_WS_TEMPLATE` | websocket address; `{port}` expands to the bound port | `ws://<advertised host>:<port>` |
+  | `BVIEW_BIND_HOST` | address to bind | `DISPLAY_HOST` (`127.0.0.1`) |
 
 **Usage:**
 ```shell
@@ -132,9 +133,23 @@ export BVIEW_WS_TEMPLATE='wss://example.internal:{port}'
 bview-comphy2D dump
 ```
 
-**Restoring all-interfaces listening** in a comphy build:
+**Listening on every interface** is a runtime choice, not a rebuild:
 ```shell
-qcc -DCOMPHY_BVIEW -DDISPLAY_HOST='"0.0.0.0"' ...
+BVIEW_BIND_HOST=0.0.0.0 bview-comphy2D dump
+```
+
+Note that `qcc` strips quotes from `-D` arguments, so a compile-time
+`-DDISPLAY_HOST='"0.0.0.0"'` does not work — it expands to a bare `0.0.0.0`
+and fails to compile. Use `BVIEW_BIND_HOST` instead.
+
+**Bind address and advertised address are distinct.** `0.0.0.0` means "every
+interface" and is not something a client can connect to, so it is never
+printed: the URL falls back to `localhost`. For real cross-machine access set
+`BVIEW_WS_TEMPLATE` to the address clients should actually use, for example
+behind a proxy that terminates TLS:
+
+```shell
+export BVIEW_WS_TEMPLATE='wss://example.internal:{port}'
 ```
 
 **wsServer compatibility:** `ws_socket_open()` keeps its signature and its

--- a/patches/README.md
+++ b/patches/README.md
@@ -88,6 +88,68 @@ bview3D --local=3000 dump
 
 ---
 
+### 2026-08-14-comphy-bview.patch
+
+**Platform:** All
+**Files modified:** `src/display.h`, `src/Makefile`, `src/wsServer/src/ws.c`, `src/wsServer/include/ws.h`
+**Related:** [bview-local-client](https://github.com/comphy-lab/bview-local-client)
+**Mutually exclusive with:** `2026-01-06-local-bview.patch`
+
+Adds two new binaries, `bview-comphy2D` and `bview-comphy3D`, built from the
+same `src/bview.c` with `-DCOMPHY_BVIEW`. The stock `bview2D`, `bview3D` and
+`bview2Dm` are left completely unchanged, including their default URL.
+
+**What it changes, in the new binaries only:**
+
+- **Binds loopback by default.** Upstream defines `DISPLAY_HOST` in
+  `src/display.h` and then never uses it, while wsServer hardcodes
+  `INADDR_ANY`, so every bview server listens on every interface. The patch
+  makes `DISPLAY_HOST` real and defaults it to `127.0.0.1`.
+
+  This matters because the websocket protocol carries no authentication:
+  `display_onmessage()` passes client text to `process_line()`, which
+  interprets drawing commands inside the running solver. Any peer that can
+  reach the port can drive that interpreter. Upstream's own documentation
+  assumes an SSH tunnel — which implies a loopback listener — but the code
+  never enforced it.
+
+- **Runtime-overridable URLs.** Neither half of the printed URL is compiled
+  in:
+
+  | Variable | Meaning | Default |
+  |---|---|---|
+  | `BVIEW_CLIENT_URL` | where the javascript client is served from | `http://localhost:8000/three.js/editor/index.html` |
+  | `BVIEW_WS_TEMPLATE` | websocket address; `{port}` expands to the bound port | `ws://<DISPLAY_HOST>:<port>` |
+
+**Usage:**
+```shell
+# Purely local, matching bview-local-client's deploy.sh
+bview-comphy2D dump
+
+# Served elsewhere, e.g. behind a reverse proxy that terminates TLS
+export BVIEW_CLIENT_URL='https://example.internal/three.js/editor/index.html'
+export BVIEW_WS_TEMPLATE='wss://example.internal:{port}'
+bview-comphy2D dump
+```
+
+**Restoring all-interfaces listening** in a comphy build:
+```shell
+qcc -DCOMPHY_BVIEW -DDISPLAY_HOST='"0.0.0.0"' ...
+```
+
+**wsServer compatibility:** `ws_socket_open()` keeps its signature and its
+all-interfaces behaviour. The patch adds `ws_socket_open_on(bindaddr, port)`
+alongside it, so nothing else linking against wsServer is affected.
+
+**Rebuild note:** the patch modifies `src/wsServer/src/ws.c`, so `libws.a` must
+be rebuilt. A full `make` handles this; patching a tree with a prebuilt
+`libws.a` and rebuilding only the bview targets produces an
+`undefined reference to ws_socket_open_on` link error.
+
+**Packaging note:** Our GitHub Release tarballs intentionally exclude this patch. To enable it during installation, pass `--comphy-bview` to the installer. It cannot be combined with `--local-bview`; the installer refuses both, since the two patches rewrite the same regions of `src/display.h`.
+
+---
+
 ## Applying Patches Manually
 
 To apply a patch to an existing Basilisk installation:

--- a/reset_install_basilisk-ref-locked.sh
+++ b/reset_install_basilisk-ref-locked.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 HARD_RESET=false
 LOCAL_BVIEW=false
+COMPHY_BVIEW=false
 SHOW_HELP=false
 REF_PROVIDED=false
 REF=""
@@ -23,6 +24,9 @@ for arg in "$@"; do
     --local-bview)
       LOCAL_BVIEW=true
       ;;
+    --comphy-bview)
+      COMPHY_BVIEW=true
+      ;;
     --help|-h)
       SHOW_HELP=true
       ;;
@@ -32,6 +36,15 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+# Both optional bview patches rewrite the same regions of src/display.h, so
+# they cannot be applied together. --comphy-bview is the superset: it also
+# provides a runtime-overridable client URL.
+if [[ "$LOCAL_BVIEW" == true && "$COMPHY_BVIEW" == true ]]; then
+  echo "Error: --local-bview and --comphy-bview are mutually exclusive." >&2
+  echo "       --comphy-bview supersedes --local-bview; use one or the other." >&2
+  exit 1
+fi
 
 print_green() { printf "\033[0;32m%s\033[0m\n" "$1"; }
 print_red() { printf "\033[0;31m%s\033[0m\n" "$1"; }
@@ -56,6 +69,10 @@ Options:
   --help, -h      Show this help message
   --hard          Force reinstall (removes existing basilisk directory)
   --local-bview   Apply optional local-bview convenience patch (enables `bview --local` URL output for bview-local-client)
+  --comphy-bview  Apply optional comphy-bview patch. Adds bview-comphy2D and
+                  bview-comphy3D, which bind loopback by default and take their
+                  client/websocket URLs from BVIEW_CLIENT_URL and
+                  BVIEW_WS_TEMPLATE. Mutually exclusive with --local-bview.
   --ref=REF       Optional. GitHub Release tag in comphy-lab/basilisk-C
                   If omitted, installs the latest GitHub release.
 
@@ -63,6 +80,7 @@ Examples:
   ./reset_install_basilisk-ref-locked.sh --hard
   ./reset_install_basilisk-ref-locked.sh --ref=v2026-01-13 --hard
   ./reset_install_basilisk-ref-locked.sh --ref=v2026-01-13 --local-bview --hard
+  ./reset_install_basilisk-ref-locked.sh --comphy-bview --hard
 
 Remote:
   curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | bash -s -- --hard
@@ -70,7 +88,8 @@ Remote:
   curl -sL https://raw.githubusercontent.com/comphy-lab/basilisk-C/main/reset_install_basilisk-ref-locked.sh | zsh  -s -- --ref=v2026-01-13 --hard
 
 Notes:
-  - GitHub Release tarballs intentionally exclude the local-bview patch; `--local-bview` downloads and applies it for the resolved release ref (latest if `--ref` is omitted, pinned if provided).
+  - GitHub Release tarballs intentionally exclude the optional bview patches; `--local-bview` and `--comphy-bview` download and apply theirs for the resolved release ref (latest if `--ref` is omitted, pinned if provided).
+  - `--comphy-bview` leaves bview2D/bview3D/bview2Dm untouched; it only adds bview-comphy2D and bview-comphy3D.
 EOF
 }
 
@@ -123,7 +142,7 @@ check_prerequisites() {
   check_tool "curl" || missing_tools+=("curl")
   check_tool "tar" || missing_tools+=("tar")
   check_tool "gawk" || missing_tools+=("gawk")
-  if [[ "$LOCAL_BVIEW" == "true" ]]; then
+  if [[ "$LOCAL_BVIEW" == "true" || "$COMPHY_BVIEW" == "true" ]]; then
     check_tool "patch" || missing_tools+=("patch")
   fi
 
@@ -216,6 +235,7 @@ apply_patches_from_dir() {
   local target_dir="$1"
   local patches_dir="$2"
   local apply_local_bview="${3:-false}"
+  local apply_comphy_bview="${4:-false}"
   local patch_failed=false
 
   print_cyan "Applying comphy-lab patches (from pinned ref)..."
@@ -242,6 +262,10 @@ apply_patches_from_dir() {
 
     if [[ "$patch_name" == *"-local-bview.patch" ]] && [[ "$apply_local_bview" != "true" ]]; then
       echo "  Skipping $patch_name (use --local-bview to apply)"
+      continue
+    fi
+    if [[ "$patch_name" == *"-comphy-bview.patch" ]] && [[ "$apply_comphy_bview" != "true" ]]; then
+      echo "  Skipping $patch_name (use --comphy-bview to apply)"
       continue
     fi
     if [[ "$patch_name" == *"-macos-"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
@@ -271,6 +295,7 @@ write_lock_stamp() {
   local ref="$2"
   local patches_dir="$3"
   local apply_local_bview="$4"
+  local apply_comphy_bview="${5:-false}"
 
   local patch_files=()
   local applied_patches=()
@@ -289,6 +314,10 @@ write_lock_stamp() {
       skipped_patches+=("$patch_name")
       continue
     fi
+    if [[ "$patch_name" == *"-comphy-bview.patch" ]] && [[ "$apply_comphy_bview" != "true" ]]; then
+      skipped_patches+=("$patch_name")
+      continue
+    fi
     if [[ "$patch_name" == *"-macos-"* ]] && [[ "$OSTYPE" != "darwin"* ]]; then
       skipped_patches+=("$patch_name")
       continue
@@ -301,6 +330,7 @@ write_lock_stamp() {
     printf "os=%s\n" "$([[ "$OSTYPE" == "darwin"* ]] && echo "darwin" || echo "linux")"
     printf "created_utc=%s\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date)"
     printf "local_bview=%s\n" "$apply_local_bview"
+    printf "comphy_bview=%s\n" "$apply_comphy_bview"
     printf "patches_applied=%s\n" "${applied_patches[*]:-}"
     printf "patches_skipped=%s\n" "${skipped_patches[*]:-}"
   } > "$lock_file"
@@ -509,15 +539,31 @@ if [[ "$HARD_RESET" == true ]] || [[ ! -d "$BASILISK_DIR" ]]; then
     exit 1
   fi
 
-  if [[ "$LOCAL_BVIEW" == true ]]; then
-    print_cyan "Applying local-bview patch (from pinned ref)..."
+  # Release tarballs intentionally exclude the optional bview patches, so they
+  # are fetched from the pinned ref on demand.
+  fetch_and_apply_optional_patch() {
+    local suffix="$1" label="$2"
+    local patches_api_url_ref raw_base_url patch_listing patch_file
+
+    print_cyan "Applying ${label} patch (from pinned ref)..."
 
     patches_api_url_ref="${PATCHES_API_URL}?ref=${REF}"
     raw_base_url="https://raw.githubusercontent.com/comphy-lab/basilisk-C/${REF}/patches"
-    patch_file="$(curl -s "$patches_api_url_ref" | grep -o '\"name\": \"[^\"]*\.patch\"' | sed 's/\"name\": \"//;s/\"//' | grep -E -- '-local-bview\.patch$' | head -n 1)"
+
+    # Fetch and parse separately. A failed request would otherwise parse to an
+    # empty string and be reported as a missing patch, sending the user looking
+    # for a file that is not the problem.
+    if ! patch_listing="$(curl -fsSL "$patches_api_url_ref")"; then
+      print_red "Error: Failed to list patches at ref '$REF' (network, rate limit, or bad ref)"
+      print_red "       Tried: $patches_api_url_ref"
+      rm -rf "$temp_dir"
+      exit 1
+    fi
+
+    patch_file="$(printf '%s\n' "$patch_listing" | grep -o '"name": "[^"]*\.patch"' | sed 's/"name": "//;s/"//' | grep -E -- "$suffix" | head -n 1)"
 
     if [[ -z "$patch_file" ]]; then
-      print_red "Error: Could not find a *-local-bview.patch file at ref '$REF'"
+      print_red "Error: Could not find a ${label} patch file at ref '$REF'"
       rm -rf "$temp_dir"
       exit 1
     fi
@@ -533,9 +579,17 @@ if [[ "$HARD_RESET" == true ]] || [[ ! -d "$BASILISK_DIR" ]]; then
       rm -rf "$temp_dir"
       exit 1
     fi
+  }
+
+  if [[ "$LOCAL_BVIEW" == true ]]; then
+    fetch_and_apply_optional_patch '-local-bview\.patch$' "local-bview"
   fi
 
-  write_lock_stamp "$LOCK_FILE" "$REF" "$patches_dest" "$LOCAL_BVIEW"
+  if [[ "$COMPHY_BVIEW" == true ]]; then
+    fetch_and_apply_optional_patch '-comphy-bview\.patch$' "comphy-bview"
+  fi
+
+  write_lock_stamp "$LOCK_FILE" "$REF" "$patches_dest" "$LOCAL_BVIEW" "$COMPHY_BVIEW"
   rm -rf "$temp_dir"
 
   build_basilisk


### PR DESCRIPTION
Adds `bview-comphy2D` and `bview-comphy3D`, built from the same `src/bview.c`
with `-DCOMPHY_BVIEW`. **Stock `bview2D`, `bview3D` and `bview2Dm` are
untouched**, including their default client URL, so nothing changes for
existing users. The patch is opt-in via a new `--comphy-bview` installer flag
and is excluded from Release tarballs, exactly like `--local-bview`.

## Why

**1. Every bview server currently listens on every interface.**

`src/display.h` defines `DISPLAY_HOST` and then never uses it, while wsServer
hardcodes `INADDR_ANY`. That matters because the websocket protocol carries no
authentication: `display_onmessage()` passes client text to `process_line()`,
which interprets drawing commands inside the running solver. Any peer that can
reach the port can drive that interpreter.

Upstream's own documentation assumes an SSH tunnel — which implies a loopback
listener — but the code never enforced it. The new binaries make
`DISPLAY_HOST` real and default it to `127.0.0.1`.

**2. The client URL is fixed at compile time.**

`basilisk.ida.upmc.fr` is baked in, so using a local or self-hosted client
means editing the printed URL by hand every time.

## What the new binaries do differently

| Variable | Meaning | Default |
|---|---|---|
| `BVIEW_CLIENT_URL` | where the javascript client is served from | `http://localhost:8000/three.js/editor/index.html` |
| `BVIEW_WS_TEMPLATE` | websocket address; `{port}` expands to the bound port | `ws://<DISPLAY_HOST>:<port>` |

No deployment address is compiled in, so the same binary serves a local client
or one behind a TLS-terminating proxy without recompiling.

Restore all-interfaces listening with `-DDISPLAY_HOST='"0.0.0.0"'`.

## Compatibility

- `ws_socket_open()` keeps its signature and its all-interfaces behaviour.
  The new `ws_socket_open_on(bindaddr, port)` sits alongside it, so anything
  else linking wsServer is unaffected.
- Mutually exclusive with `--local-bview`; the installer refuses both, since
  the two patches rewrite the same regions of `src/display.h`.
- `src/wsServer/src/ws.c` changes, so `libws.a` must be rebuilt. A full `make`
  handles it; rebuilding only the bview targets against a stale `libws.a`
  gives `undefined reference to ws_socket_open_on`. Documented in
  `patches/README.md`.

## Validation

Built and run, not just inspected:

```
bview-comphy2D default:   http://localhost:8000/three.js/editor/index.html?ws://127.0.0.1:7100
bview-comphy2D + env:     https://example.internal/three.js/editor/index.html?wss://example.internal:7100
stock bview2D:            http://basilisk.ida.upmc.fr/three.js/editor/index.html?ws://<host>:7100

bind: bview-comphy2D -> 127.0.0.1:7100
      bview2D        -> 0.0.0.0:7100    (unchanged)
```

Both binaries compile. `{port}` substitution verified. Installer: `bash -n`
clean, no new shellcheck warnings, help text renders, and the mutual-exclusion
guard rejects `--local-bview --comphy-bview`.

Also hardens the optional-patch download path: the GitHub API response is now
fetched as a checked request before parsing, so a network failure or rate
limit reports itself instead of surfacing as a misleading "could not find
patch file".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional COMPHY BVIEW support with loopback-by-default display servers.
  * Added configurable client and WebSocket URLs, runtime overrides, and port substitution.
  * Added dedicated 2D and 3D COMPHY BVIEW build targets.
  * Added explicit IPv4 binding support for WebSocket connections.
  * Added installer support, prerequisite checks, configuration tracking, and compatibility with existing BVIEW options.

* **Documentation**
  * Added usage, compatibility, rebuilding, installation, and configuration guidance for COMPHY BVIEW.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->